### PR TITLE
Fix deadlock in update_dynamic_parameters

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -7,7 +7,7 @@ descriptor.read_only = {{parameter_read_only}};
 auto parameter = rclcpp::ParameterType::PARAMETER_{{parameter_type}};
 {% endif -%}
 {%- if parameter_value|length %}
-auto parameter = rclcpp::ParameterValue(params_.{{parameter_value}});
+auto parameter = rclcpp::ParameterValue(updated_params.{{parameter_value}});
 {% endif -%}
 parameters_interface_->declare_parameter(prefix_ + "{{parameter_name}}", parameter, descriptor);
 {% endfilter -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
@@ -77,7 +77,7 @@ struct StackParams {
     }
 
     StackParams get_stack_params() {
-      std::lock_guard<std::mutex> lock(mutex_);
+      Params params = get_params();
       StackParams output;
 
 {%- filter indent(width=6) %}
@@ -88,7 +88,7 @@ struct StackParams {
     }
 
     void refresh_dynamic_parameters() {
-      std::lock_guard<std::mutex> lock(mutex_);
+      auto updated_params = get_params();
       // TODO remove any destroyed dynamic parameters
 {%- filter indent(width=6) %}
 {{remove_dynamic_parameters}}
@@ -101,12 +101,7 @@ struct StackParams {
     }
 
     rcl_interfaces::msg::SetParametersResult update(const std::vector<rclcpp::Parameter> &parameters) {
-      Params updated_params;
-      {
-        // Copy params_ so we only update it if all validation succeeds
-        std::lock_guard<std::mutex> lock(mutex_);
-        updated_params = params_;
-      }
+      auto updated_params = get_params();
 
       for (const auto &param: parameters) {
 {%- filter indent(width=8) %}
@@ -122,14 +117,12 @@ struct StackParams {
       }
 {%- endif %}
       updated_params.__stamp = clock_.now();
-      {
-        std::lock_guard<std::mutex> lock(mutex_);
-        params_ = updated_params;
-      }
+      update_interal_params(updated_params);
       return parameter_traits::OK;
     }
 
     void declare_params(){
+      auto updated_params = get_params();
       // declare all parameters and give default values to non-required ones
 {%- filter indent(width=6) %}
 {{declare_params}}
@@ -147,10 +140,16 @@ struct StackParams {
 {%- endfilter %}
 {%- endif %}
 
-      params_.__stamp = clock_.now();
+      updated_params.__stamp = clock_.now();
+      update_interal_params(updated_params);
     }
 
     private:
+      void update_interal_params(Params updated_params) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        params_ = updated_params;
+      }
+
       std::string prefix_;
       Params params_;
       rclcpp::Clock clock_;

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/remove_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/remove_runtime_parameter
@@ -1,6 +1,6 @@
 {
-    std::set<std::string> {{mapped_param}}_set(params_.{{mapped_param}}.begin(), params_.{{mapped_param}}.end());
-    for (const auto &it: params_.{{parameter_map}}) {
+    std::set<std::string> {{mapped_param}}_set(updated_params.{{mapped_param}}.begin(), updated_params.{{mapped_param}}.end());
+    for (const auto &it: updated_params.{{parameter_map}}) {
         if ({{mapped_param}}_set.find(it.first) == {{mapped_param}}_set.end()) {
             auto param_name = fmt::format("{}{}.{}.{}", prefix_, "{{struct_name}}", it.first, "{{parameter_field}}");
             parameters_interface_->undeclare_parameter(param_name);

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/set_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/set_parameter
@@ -2,4 +2,4 @@ param = parameters_interface_->get_parameter(prefix_ + "{{parameter_name}}");
 {% if parameter_validations|length -%}
 {{parameter_validations-}}
 {% endif -%}
-params_.{{parameter_name}} = param.{{parameter_as_function}};
+updated_params.{{parameter_name}} = param.{{parameter_as_function}};

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/set_stack_params
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/set_stack_params
@@ -1,1 +1,1 @@
-output.{{parameter_name}} = params_.{{parameter_name}};
+output.{{parameter_name}} = params.{{parameter_name}};

--- a/generate_parameter_library_py/generate_parameter_library_py/main.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/main.py
@@ -675,7 +675,7 @@ class DeclareRuntimeParameter(DeclareParameterBase):
     ):
         super().__init__(code_gen_variable, parameter_description, parameter_read_only)
         self.set_runtime_parameter = None
-        self.param_struct_instance = "params_"
+        self.param_struct_instance = "updated_params"
 
     @typechecked
     def add_set_runtime_parameter(self, set_runtime_parameter: SetRuntimeParameter):


### PR DESCRIPTION
This fixes a deadlock condition in update_dynamic_parameters. The reason for the deadlock is that when it was declaring new parameters, the mutex was locked and the update callback would be called that would also try to lock the mutex.

To fix this, I updated all the usage of the internal state `params_` to only be accessed through the getter method and a new private setter method. This means that the methods inside ParamListener only lock the mutex to copy or write to this internal state value instead of locking for the full duration of some of the methods that can cause callbacks to fire that might also need to lock the mutex.