### PR TITLE
Test validators and fix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,23 +212,38 @@ This will require this string_array to have these properties:
 * Values are only in the set `["position", "velocity", "acceleration", "effort",]`
 
 You will note that some validators have a suffix of `<>`, this tells the code generator to pass the C++ type of the parameter as a function template.
+Some of these validators work only on value types, some on string types, and others on array types.
 The built-in validator functions provided by this package are:
 
-| Function               | Arguments           | Description                                                           |
-|------------------------|---------------------|-----------------------------------------------------------------------|
-| unique<>               | []                  | Array type parameter contains no duplicates                           |
-| subset_of<>            | [[val1, val2, ...]] | Every element of array type parameter is contained within argument    |
-| fixed_size<>           | [length]            | Length of array or string is specified length                         |
-| size_gt<>              | [length]            | Length of array or string is greater than specified length            |
-| size_lt<>              | [length]            | Length of array or string is less less specified length               |
-| not_empty<>            | []                  | Array or string parameter is not empty                                |
-| element_bounds<>       | [lower, upper]      | Bounds checking for every element of array type parameter (inclusive) |
-| lower_element_bounds<> | [lower]             | Lower bound for every element of array type parameter (inclusive)     |
-| upper_element_bounds<> | [upper]             | Upper bound for every element of array type parameter (inclusive)     |
-| bounds<>               | [lower, upper]      | Bounds checking for a scalar type parameter (inclusive)               |
-| lower_bounds<>         | [lower]             | Lower bounds for a scalar type parameter (inclusive)                  |
-| upper_bounds<>         | [upper]             | Upper bounds for a scalar type parameter (inclusive)                  |
-| one_of<>               | [[val1, val2, ...]] | Scalar type parameter is one of the specified values                  |
+**Value validators**
+| Function               | Arguments           | Description                          |
+|------------------------|---------------------|--------------------------------------|
+| bounds<>               | [lower, upper]      | Bounds checking (inclusive)          |
+| lower_bounds<>         | [lower]             | Lower bounds (inclusive)             |
+| upper_bounds<>         | [upper]             | Upper bounds (inclusive)             |
+| one_of<>               | [[val1, val2, ...]] | Value is one of the specified values |
+
+**String validators**
+| Function               | Arguments           | Description                                     |
+|------------------------|---------------------|-------------------------------------------------|
+| fixed_size<>           | [length]            | Length string is specified length               |
+| size_gt<>              | [length]            | Length string is greater than specified length  |
+| size_lt<>              | [length]            | Length string is less less specified length     |
+| not_empty<>            | []                  | String parameter is not empty                   |
+| one_of<>               | [[val1, val2, ...]] | String is one of the specified values           |
+
+**Array validators**
+| Function               | Arguments           | Description                                          |
+|------------------------|---------------------|------------------------------------------------------|
+| unique<>               | []                  | Contains no duplicates                               |
+| subset_of<>            | [[val1, val2, ...]] | Every element is one of the list                     |
+| fixed_size<>           | [length]            | Number of elements is specified length               |
+| size_gt<>              | [length]            | Number of elements is greater than specified length  |
+| size_lt<>              | [length]            | Number of elements is less less specified length     |
+| not_empty<>            | []                  | Has at-least one element                             |
+| element_bounds<>       | [lower, upper]      | Bounds checking each element (inclusive)             |
+| lower_element_bounds<> | [lower]             | Lower bound for each element (inclusive)             |
+| upper_element_bounds<> | [upper]             | Upper bound for each element (inclusive)             |
 
 ### Custom validator functions
 Validators are functions that return a `Result` type and accept a `rclcpp::Parameter const&` as their first argument and any number of arguments after that can be specified in YAML.

--- a/generate_parameter_library_py/setup.py
+++ b/generate_parameter_library_py/setup.py
@@ -31,7 +31,6 @@ setup(
     install_requires=["setuptools", "typeguard", "jinja2"],
     package_data={
         "": [
-            "validators/validators.hpp",
             "jinja_templates/declare_parameter",
             "jinja_templates/set_parameter",
             "jinja_templates/declare_struct",

--- a/parameter_traits/include/parameter_traits/validators.hpp
+++ b/parameter_traits/include/parameter_traits/validators.hpp
@@ -35,6 +35,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <fmt/core.h>
+#include <fmt/ranges.h>
 #include <parameter_traits/comparison.hpp>
 #include <parameter_traits/result.hpp>
 
@@ -56,8 +58,9 @@ Result subset_of(rclcpp::Parameter const& parameter,
 
   for (auto const& value : input_values) {
     if (!contains(valid_values, value)) {
-      return ERROR("Invalid entry '{}' for parameter '{}'. Not in set: {}",
-                   value, parameter.get_name(), valid_values);
+      return ERROR(fmt::format(
+          "Invalid entry '{}' for parameter '{}'. Not in set: {}", value,
+          parameter.get_name(), fmt::join(valid_values, ", ")));
     }
   }
 
@@ -67,7 +70,7 @@ Result subset_of(rclcpp::Parameter const& parameter,
 template <typename T, typename F>
 Result size_cmp(rclcpp::Parameter const& parameter, size_t size,
                 std::string const& cmp_str, F cmp) {
-  if (std::is_same<T, std::string>::value) {
+  if (parameter.get_type() == rclcpp::ParameterType::PARAMETER_STRING) {
     if (auto value = parameter.get_value<std::string>();
         !cmp(value.size(), size)) {
       return ERROR("Invalid length '{}' for parameter '{}'. Required {}: {}",
@@ -101,7 +104,7 @@ Result size_lt(rclcpp::Parameter const& parameter, size_t size) {
 
 template <typename T>
 Result not_empty(rclcpp::Parameter const& parameter) {
-  if (std::is_same<T, std::string>::value) {
+  if (parameter.get_type() == rclcpp::ParameterType::PARAMETER_STRING) {
     if (auto param_value = parameter.get_value<std::string>();
         param_value.empty()) {
       return ERROR("The parameter '{}' cannot be empty.", parameter.get_name());

--- a/parameter_traits/test/CMakeLists.txt
+++ b/parameter_traits/test/CMakeLists.txt
@@ -2,3 +2,6 @@ find_package(ament_cmake_gtest REQUIRED)
 
 ament_add_gtest(comparison_tests comparison_tests.cpp)
 target_link_libraries(comparison_tests parameter_traits)
+
+ament_add_gtest(validators_tests validators_tests.cpp)
+target_link_libraries(validators_tests parameter_traits)

--- a/parameter_traits/test/validators_tests.cpp
+++ b/parameter_traits/test/validators_tests.cpp
@@ -1,0 +1,460 @@
+// Copyright (c) 2022, PickNik Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+
+#include <string>
+#include <vector>
+
+#include <rclcpp/parameter.hpp>
+
+#include <parameter_traits/result.hpp>
+#include <parameter_traits/validators.hpp>
+
+namespace parameter_traits {
+using rclcpp::Parameter;
+
+TEST(ValidatorsTests, Bounds) {
+  EXPECT_TRUE(bounds<double>(Parameter{"", 1.0}, 1.0, 5.0).success());
+  EXPECT_TRUE(bounds<double>(Parameter{"", 4.3}, 1.0, 5.0).success());
+  EXPECT_TRUE(bounds<double>(Parameter{"", 5.0}, 1.0, 5.0).success());
+  EXPECT_FALSE(bounds<double>(Parameter{"", -4.3}, 1.0, 5.0).success());
+  EXPECT_FALSE(bounds<double>(Parameter{"", 10.2}, 1.0, 5.0).success());
+
+  EXPECT_TRUE(bounds<int64_t>(Parameter{"", 1}, 1, 5).success());
+  EXPECT_TRUE(bounds<int64_t>(Parameter{"", 4}, 1, 5).success());
+  EXPECT_TRUE(bounds<int64_t>(Parameter{"", 5}, 1, 5).success());
+  EXPECT_FALSE(bounds<int64_t>(Parameter{"", -4}, 1, 5).success());
+  EXPECT_FALSE(bounds<int64_t>(Parameter{"", 10}, 1, 5).success());
+
+  EXPECT_TRUE(bounds<bool>(Parameter{"", true}, false, true).success());
+  EXPECT_FALSE(bounds<bool>(Parameter{"", false}, true, true).success());
+  EXPECT_FALSE(bounds<bool>(Parameter{"", true}, false, false).success());
+
+  EXPECT_ANY_THROW(bounds<int64_t>(Parameter{"", ""}, 1, 5));
+  EXPECT_ANY_THROW(bounds<std::string>(Parameter{"", 4}, "", "foo"));
+}
+
+TEST(ValidatorsTests, LowerBounds) {
+  EXPECT_TRUE(lower_bounds<double>(Parameter{"", 2.0}, 2.0).success());
+  EXPECT_TRUE(lower_bounds<double>(Parameter{"", 4.3}, 1.0).success());
+  EXPECT_FALSE(lower_bounds<double>(Parameter{"", -4.3}, 1.0).success());
+
+  EXPECT_TRUE(lower_bounds<int64_t>(Parameter{"", 1}, 1).success());
+  EXPECT_TRUE(lower_bounds<int64_t>(Parameter{"", 4}, 1).success());
+  EXPECT_FALSE(lower_bounds<int64_t>(Parameter{"", -4}, 1).success());
+
+  EXPECT_TRUE(lower_bounds<bool>(Parameter{"", true}, false).success());
+  EXPECT_FALSE(lower_bounds<bool>(Parameter{"", false}, true).success());
+  EXPECT_TRUE(lower_bounds<bool>(Parameter{"", true}, true).success());
+}
+
+TEST(ValidatorsTests, UpperBounds) {
+  EXPECT_TRUE(upper_bounds<double>(Parameter{"", 2.0}, 2.0).success());
+  EXPECT_FALSE(upper_bounds<double>(Parameter{"", 4.3}, 1.0).success());
+  EXPECT_TRUE(upper_bounds<double>(Parameter{"", -4.3}, 1.0).success());
+
+  EXPECT_TRUE(upper_bounds<int64_t>(Parameter{"", 1}, 1).success());
+  EXPECT_FALSE(upper_bounds<int64_t>(Parameter{"", 4}, 1).success());
+  EXPECT_TRUE(upper_bounds<int64_t>(Parameter{"", -4}, 1).success());
+
+  EXPECT_FALSE(upper_bounds<bool>(Parameter{"", true}, false).success());
+  EXPECT_TRUE(upper_bounds<bool>(Parameter{"", false}, true).success());
+  EXPECT_TRUE(upper_bounds<bool>(Parameter{"", true}, true).success());
+}
+
+TEST(ValidatorsTests, OneOf) {
+  EXPECT_TRUE(
+      one_of<double>(Parameter{"", 2.0}, std::vector<double>{2.0}).success());
+  EXPECT_TRUE(
+      one_of<double>(Parameter{"", 2.0}, std::vector<double>{1.0, 2.0, 3.5})
+          .success());
+  EXPECT_FALSE(
+      one_of<double>(Parameter{"", 0.0}, std::vector<double>{1.0, 2.0, 3.5})
+          .success());
+  EXPECT_FALSE(
+      one_of<double>(Parameter{"", 0.0}, std::vector<double>{}).success());
+
+  EXPECT_TRUE(
+      one_of<int64_t>(Parameter{"", 1}, std::vector<int64_t>{1}).success());
+  EXPECT_TRUE(
+      one_of<int64_t>(Parameter{"", 1}, std::vector<int64_t>{1, 2, 3, 4})
+          .success());
+  EXPECT_FALSE(
+      one_of<int64_t>(Parameter{"", 0}, std::vector<int64_t>{1, 2, 3, 4})
+          .success());
+  EXPECT_FALSE(
+      one_of<int64_t>(Parameter{"", 0}, std::vector<int64_t>{}).success());
+
+  EXPECT_FALSE(
+      one_of<bool>(Parameter{"", true}, std::vector<bool>{false}).success());
+  EXPECT_TRUE(one_of<bool>(Parameter{"", true}, std::vector<bool>{false, true})
+                  .success());
+  EXPECT_TRUE(
+      one_of<bool>(Parameter{"", true}, std::vector<bool>{true}).success());
+  EXPECT_FALSE(
+      one_of<bool>(Parameter{"", true}, std::vector<bool>{}).success());
+}
+
+TEST(ValidatorsTests, FixedSizeString) {
+  EXPECT_TRUE(fixed_size<std::string>(Parameter{"", "foo"}, 3).success());
+  EXPECT_TRUE(fixed_size<std::string>(Parameter{"", ""}, 0).success());
+  EXPECT_FALSE(fixed_size<std::string>(Parameter{"", "foo"}, 0).success());
+  EXPECT_FALSE(fixed_size<std::string>(Parameter{"", "foo"}, 5).success());
+}
+
+TEST(ValidatorsTests, SizeGtString) {
+  EXPECT_TRUE(size_gt<std::string>(Parameter{"", "foo"}, 2).success());
+  EXPECT_FALSE(size_gt<std::string>(Parameter{"", ""}, 0).success());
+  EXPECT_FALSE(size_gt<std::string>(Parameter{"", "foo"}, 5).success());
+}
+
+TEST(ValidatorsTests, SizeLtString) {
+  EXPECT_TRUE(size_lt<std::string>(Parameter{"", "foo"}, 5).success());
+  EXPECT_FALSE(size_lt<std::string>(Parameter{"", ""}, 0).success());
+  EXPECT_FALSE(size_lt<std::string>(Parameter{"", "foo"}, 3).success());
+}
+
+TEST(ValidatorsTests, NotEmptyString) {
+  EXPECT_TRUE(not_empty<std::string>(Parameter{"", "foo"}).success());
+  EXPECT_FALSE(not_empty<std::string>(Parameter{"", ""}).success());
+}
+
+TEST(ValidatorsTests, OneOfString) {
+  EXPECT_TRUE(one_of<std::string>(Parameter{"", "foo"},
+                                  std::vector<std::string>{"foo", "baz"})
+                  .success());
+  EXPECT_FALSE(one_of<std::string>(Parameter{"", ""},
+                                   std::vector<std::string>{"foo", "baz"})
+                   .success());
+}
+
+TEST(ValidatorsTests, UniqueArray) {
+  EXPECT_TRUE(
+      unique<std::string>(Parameter{"", std::vector<std::string>{"", "1", "2"}})
+          .success());
+  EXPECT_TRUE(
+      unique<std::string>(Parameter{"", std::vector<std::string>{}}).success());
+  EXPECT_FALSE(
+      unique<std::string>(Parameter{"", std::vector<std::string>{"foo", "foo"}})
+          .success());
+
+  EXPECT_TRUE(unique<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}})
+                  .success());
+  EXPECT_TRUE(unique<double>(Parameter{"", std::vector<double>{}}).success());
+  EXPECT_FALSE(
+      unique<double>(Parameter{"", std::vector<double>{1.1, 1.1}}).success());
+
+  EXPECT_TRUE(
+      unique<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}).success());
+  EXPECT_TRUE(unique<int64_t>(Parameter{"", std::vector<int64_t>{}}).success());
+  EXPECT_FALSE(
+      unique<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}).success());
+
+  EXPECT_TRUE(
+      unique<bool>(Parameter{"", std::vector<bool>{true, false}}).success());
+  EXPECT_TRUE(unique<bool>(Parameter{"", std::vector<bool>{}}).success());
+  EXPECT_FALSE(
+      unique<bool>(Parameter{"", std::vector<bool>{false, false}}).success());
+}
+
+TEST(ValidatorsTests, SubsetOfArray) {
+  EXPECT_TRUE(subset_of<std::string>(
+                  Parameter{"", std::vector<std::string>{"", "1", "2"}},
+                  std::vector<std::string>{"", "1", "2", "three"})
+                  .success());
+  EXPECT_TRUE(
+      subset_of<std::string>(Parameter{"", std::vector<std::string>{}},
+                             std::vector<std::string>{"", "1", "2", "three"})
+          .success());
+  EXPECT_FALSE(subset_of<std::string>(
+                   Parameter{"", std::vector<std::string>{"foo", "foo"}},
+                   std::vector<std::string>{"", "1", "2", "three"})
+                   .success());
+
+  EXPECT_TRUE(
+      subset_of<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}},
+                        std::vector<double>{1.0, 2.2, 1.1})
+          .success());
+  EXPECT_TRUE(subset_of<double>(Parameter{"", std::vector<double>{}},
+                                std::vector<double>{10, 22})
+                  .success());
+  EXPECT_FALSE(subset_of<double>(Parameter{"", std::vector<double>{1.1, 1.1}},
+                                 std::vector<double>{1.0, 2.2})
+                   .success());
+
+  EXPECT_TRUE(subset_of<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}},
+                                 std::vector<int64_t>{1, 2, 3})
+                  .success());
+  EXPECT_TRUE(subset_of<int64_t>(Parameter{"", std::vector<int64_t>{}},
+                                 std::vector<int64_t>{1, 2, 3})
+                  .success());
+  EXPECT_FALSE(subset_of<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}},
+                                  std::vector<int64_t>{1, 2, 3})
+                   .success());
+
+  EXPECT_TRUE(subset_of<bool>(Parameter{"", std::vector<bool>{true, false}},
+                              std::vector<bool>{true, false})
+                  .success());
+  EXPECT_TRUE(subset_of<bool>(Parameter{"", std::vector<bool>{}},
+                              std::vector<bool>{true, false})
+                  .success());
+  EXPECT_FALSE(subset_of<bool>(Parameter{"", std::vector<bool>{false, false}},
+                               std::vector<bool>{true})
+                   .success());
+}
+
+TEST(ValidatorsTests, FixedSizeArray) {
+  EXPECT_TRUE(fixed_size<std::string>(
+                  Parameter{"", std::vector<std::string>{"", "1", "2"}}, 3)
+                  .success());
+  EXPECT_TRUE(
+      fixed_size<std::string>(Parameter{"", std::vector<std::string>{}}, 0)
+          .success());
+  EXPECT_FALSE(fixed_size<std::string>(
+                   Parameter{"", std::vector<std::string>{"foo", "foo"}}, 3)
+                   .success());
+
+  EXPECT_TRUE(
+      fixed_size<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 3)
+          .success());
+  EXPECT_TRUE(
+      fixed_size<double>(Parameter{"", std::vector<double>{}}, 0).success());
+  EXPECT_FALSE(
+      fixed_size<double>(Parameter{"", std::vector<double>{1.1, 1.1}}, 3)
+          .success());
+
+  EXPECT_TRUE(
+      fixed_size<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}, 3)
+          .success());
+  EXPECT_TRUE(
+      fixed_size<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0).success());
+  EXPECT_FALSE(
+      fixed_size<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}, 0)
+          .success());
+
+  EXPECT_TRUE(fixed_size<bool>(Parameter{"", std::vector<bool>{true, false}}, 2)
+                  .success());
+  EXPECT_TRUE(
+      fixed_size<bool>(Parameter{"", std::vector<bool>{}}, 0).success());
+  EXPECT_FALSE(
+      fixed_size<bool>(Parameter{"", std::vector<bool>{false, false}}, 0)
+          .success());
+}
+
+TEST(ValidatorsTests, SizeGtArray) {
+  EXPECT_TRUE(size_gt<std::string>(
+                  Parameter{"", std::vector<std::string>{"", "1", "2"}}, 1)
+                  .success());
+  EXPECT_FALSE(
+      size_gt<std::string>(Parameter{"", std::vector<std::string>{}}, 0)
+          .success());
+  EXPECT_FALSE(size_gt<std::string>(
+                   Parameter{"", std::vector<std::string>{"foo", "foo"}}, 3)
+                   .success());
+
+  EXPECT_TRUE(
+      size_gt<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 2)
+          .success());
+  EXPECT_FALSE(
+      size_gt<double>(Parameter{"", std::vector<double>{}}, 0).success());
+  EXPECT_FALSE(size_gt<double>(Parameter{"", std::vector<double>{1.1, 1.1}}, 3)
+                   .success());
+
+  EXPECT_TRUE(size_gt<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}, 2)
+                  .success());
+  EXPECT_FALSE(
+      size_gt<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0).success());
+  EXPECT_TRUE(size_gt<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}, 0)
+                  .success());
+
+  EXPECT_TRUE(size_gt<bool>(Parameter{"", std::vector<bool>{true, false}}, 0)
+                  .success());
+  EXPECT_FALSE(size_gt<bool>(Parameter{"", std::vector<bool>{}}, 0).success());
+  EXPECT_TRUE(size_gt<bool>(Parameter{"", std::vector<bool>{false, false}}, 0)
+                  .success());
+}
+
+TEST(ValidatorsTests, SizeLtArray) {
+  EXPECT_FALSE(size_lt<std::string>(
+                   Parameter{"", std::vector<std::string>{"", "1", "2"}}, 1)
+                   .success());
+  EXPECT_FALSE(
+      size_lt<std::string>(Parameter{"", std::vector<std::string>{}}, 0)
+          .success());
+  EXPECT_TRUE(size_lt<std::string>(
+                  Parameter{"", std::vector<std::string>{"foo", "foo"}}, 3)
+                  .success());
+
+  EXPECT_FALSE(
+      size_lt<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 2)
+          .success());
+  EXPECT_FALSE(
+      size_lt<double>(Parameter{"", std::vector<double>{}}, 0).success());
+  EXPECT_TRUE(size_lt<double>(Parameter{"", std::vector<double>{1.1, 1.1}}, 3)
+                  .success());
+
+  EXPECT_FALSE(size_lt<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}, 2)
+                   .success());
+  EXPECT_FALSE(
+      size_lt<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0).success());
+  EXPECT_FALSE(size_lt<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}, 0)
+                   .success());
+
+  EXPECT_TRUE(size_lt<bool>(Parameter{"", std::vector<bool>{true, false}}, 3)
+                  .success());
+  EXPECT_FALSE(size_lt<bool>(Parameter{"", std::vector<bool>{}}, 0).success());
+  EXPECT_FALSE(size_lt<bool>(Parameter{"", std::vector<bool>{false, false}}, 0)
+                   .success());
+}
+
+TEST(ValidatorsTests, NotEmptyArray) {
+  EXPECT_TRUE(not_empty<std::string>(
+                  Parameter{"", std::vector<std::string>{"", "1", "2"}})
+                  .success());
+  EXPECT_FALSE(not_empty<std::string>(Parameter{"", std::vector<std::string>{}})
+                   .success());
+
+  EXPECT_TRUE(
+      not_empty<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}})
+          .success());
+  EXPECT_FALSE(
+      not_empty<double>(Parameter{"", std::vector<double>{}}).success());
+
+  EXPECT_TRUE(not_empty<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}})
+                  .success());
+  EXPECT_FALSE(
+      not_empty<int64_t>(Parameter{"", std::vector<int64_t>{}}).success());
+
+  EXPECT_TRUE(
+      not_empty<bool>(Parameter{"", std::vector<bool>{true, false}}).success());
+  EXPECT_FALSE(not_empty<bool>(Parameter{"", std::vector<bool>{}}).success());
+}
+
+TEST(ValidatorsTests, ElementBoundsArray) {
+  EXPECT_TRUE(element_bounds<double>(
+                  Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 0.0, 3.0)
+                  .success());
+  EXPECT_TRUE(
+      element_bounds<double>(Parameter{"", std::vector<double>{}}, 0.0, 1.0)
+          .success());
+
+  EXPECT_TRUE(element_bounds<int64_t>(
+                  Parameter{"", std::vector<int64_t>{1, 2, 3}}, 0, 5)
+                  .success());
+  EXPECT_FALSE(element_bounds<int64_t>(
+                   Parameter{"", std::vector<int64_t>{1, 2, 3}}, -5, 0)
+                   .success());
+  EXPECT_TRUE(
+      element_bounds<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0, 1)
+          .success());
+
+  EXPECT_TRUE(element_bounds<bool>(
+                  Parameter{"", std::vector<bool>{true, false}}, false, true)
+                  .success());
+  EXPECT_FALSE(element_bounds<bool>(
+                   Parameter{"", std::vector<bool>{true, false}}, true, false)
+                   .success());
+  EXPECT_FALSE(element_bounds<bool>(
+                   Parameter{"", std::vector<bool>{true, false}}, false, false)
+                   .success());
+  EXPECT_TRUE(
+      element_bounds<bool>(Parameter{"", std::vector<bool>{}}, true, false)
+          .success());
+}
+
+TEST(ValidatorsTests, LowerElementBoundsArray) {
+  EXPECT_TRUE(lower_element_bounds<double>(
+                  Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 0.0)
+                  .success());
+  EXPECT_TRUE(
+      lower_element_bounds<double>(Parameter{"", std::vector<double>{}}, 0.0)
+          .success());
+
+  EXPECT_TRUE(lower_element_bounds<int64_t>(
+                  Parameter{"", std::vector<int64_t>{1, 2, 3}}, 0)
+                  .success());
+  EXPECT_FALSE(lower_element_bounds<int64_t>(
+                   Parameter{"", std::vector<int64_t>{1, 2, 3}}, 3)
+                   .success());
+  EXPECT_TRUE(
+      lower_element_bounds<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0)
+          .success());
+
+  EXPECT_TRUE(lower_element_bounds<bool>(
+                  Parameter{"", std::vector<bool>{true, false}}, false)
+                  .success());
+  EXPECT_FALSE(lower_element_bounds<bool>(
+                   Parameter{"", std::vector<bool>{true, false}}, true)
+                   .success());
+  EXPECT_TRUE(lower_element_bounds<bool>(
+                  Parameter{"", std::vector<bool>{true, false}}, false)
+                  .success());
+  EXPECT_TRUE(
+      lower_element_bounds<bool>(Parameter{"", std::vector<bool>{}}, true)
+          .success());
+}
+
+TEST(ValidatorsTests, UpperElementBoundsArray) {
+  EXPECT_FALSE(upper_element_bounds<double>(
+                   Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 0.0)
+                   .success());
+  EXPECT_TRUE(
+      upper_element_bounds<double>(Parameter{"", std::vector<double>{}}, 0.0)
+          .success());
+
+  EXPECT_FALSE(upper_element_bounds<int64_t>(
+                   Parameter{"", std::vector<int64_t>{1, 2, 3}}, 0)
+                   .success());
+  EXPECT_TRUE(upper_element_bounds<int64_t>(
+                  Parameter{"", std::vector<int64_t>{1, 2, 3}}, 3)
+                  .success());
+  EXPECT_TRUE(
+      upper_element_bounds<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0)
+          .success());
+
+  EXPECT_FALSE(upper_element_bounds<bool>(
+                   Parameter{"", std::vector<bool>{true, false}}, false)
+                   .success());
+  EXPECT_TRUE(upper_element_bounds<bool>(
+                  Parameter{"", std::vector<bool>{true, false}}, true)
+                  .success());
+  EXPECT_FALSE(upper_element_bounds<bool>(
+                   Parameter{"", std::vector<bool>{true, false}}, false)
+                   .success());
+  EXPECT_TRUE(
+      upper_element_bounds<bool>(Parameter{"", std::vector<bool>{}}, true)
+          .success());
+}
+
+}  // namespace parameter_traits
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Fixes #59 

This PR clarifies which validators can be used for which types of parameters in the README, fixes the odd bugs that @destogl found with vectors of strings, and adds unit tests for all the validator functions.