### PR TITLE
🈵 Support use of '_' in mapped parameters.

### DIFF
--- a/example/src/parameters.yaml
+++ b/example/src/parameters.yaml
@@ -18,6 +18,12 @@ admittance_controller:
     default_value: ["joint1", "joint2", "joint3"],
     description: "specifies which joints will be used by the controller",
   }
+  dof_names: {
+    type: string_array,
+    default_value: ["x", "y", "rz"],
+    description: "specifies which joints will be used by the controller",
+  }
+
   pid:
     rate: {
       type: double,
@@ -44,6 +50,15 @@ admittance_controller:
         default_value: 1.0,
         description: "derivative gain term"
       }
+
+  gains:
+    __map_dof_names:
+      k: {
+        type: double,
+        default_value: 2.0,
+        description: "general gain"
+      }
+
   fixed_string: {
     type: string_fixed_25,
     default_value: "string_value",

--- a/generate_parameter_library_py/generate_parameter_library_py/main.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/main.py
@@ -112,8 +112,8 @@ def get_dynamic_parameter_field(yaml_parameter_name: str):
 
 def get_dynamic_mapped_parameter(yaml_parameter_name: str):
     tmp = yaml_parameter_name.split(".")
-    tmp2 = tmp[-2].split("_")
-    mapped_param = tmp2[-1]
+    tmp2 = tmp[-2]
+    mapped_param = tmp2.replace("__map_", "")
     return mapped_param
 
 
@@ -445,7 +445,7 @@ class DeclareStruct:
 
         if is_mapped_parameter(self.struct_name):
             map_val_type = pascal_case(self.struct_name)
-            map_name = self.struct_name.split("_")[-1] + "_map"
+            map_name = self.struct_name.replace("__map_", "") + "_map"
             map_name = map_name.replace(".", "_")
         else:
             map_val_type = ""


### PR DESCRIPTION
Adding support to map parameters which have "_" in their name.
This also make the code more about explicit keywords and without assumption about name format.

Check the extended example parameter setup for more details.
