### PR TITLE
Added -- for ros-args to find

### DIFF
--- a/generate_parameter_library/cmake/generate_parameter_library.cmake
+++ b/generate_parameter_library/cmake/generate_parameter_library.cmake
@@ -100,7 +100,7 @@ function(add_rostest_with_parameters_gtest TARGET SOURCES YAML_FILE)
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TARGET}.gtest.xml")
   ament_add_test(
     ${TARGET}
-    COMMAND ${executable} --ros-args --params-file ${YAML_FILE}
+    COMMAND ${executable} --ros-args --params-file ${YAML_FILE} --
     --gtest_output=xml:${result_file}
     OUTPUT_FILE ${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TARGET}.txt
     RESULT_FILE ${result_file}
@@ -116,7 +116,7 @@ function(add_rostest_with_parameters_gmock TARGET SOURCES YAML_FILE)
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TARGET}.gtest.xml")
   ament_add_test(
     ${TARGET}
-    COMMAND ${executable} --ros-args --params-file ${YAML_FILE}
+    COMMAND ${executable} --ros-args --params-file ${YAML_FILE} --
     --gtest_output=xml:${result_file}
     OUTPUT_FILE ${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TARGET}.txt
     RESULT_FILE ${result_file}


### PR DESCRIPTION
I don't know if anyone else had this issue, but although [the docs](https://design.ros2.org/articles/ros_command_line_arguments.html) states:

> Extraction
> Command line argument extraction happens within rcl. When an instance of the --ros-args flag is found in argv, until either a double dash token (--) is found or the end of the argument array is reached, all arguments that follow are taken as ROS specific arguments to be parsed as such. Remaining arguments can still be accessed by the user via rcl API.

I don't think the double dash of "--gtest_output=xml:${result_file}" counts. In my ros2_control fork using generate_parameter_library I get the following error without the trailing "--":

- joint_limits_rosparam_test
  <<< failure message
    -- run_test.py: invoking following command in '/home/wrock/colcon_ws/build/joint_limits':
     - /home/wrock/colcon_ws/build/joint_limits/joint_limits_rosparam_test --ros-args --params-file /home/wrock/colcon_ws/src/ros2_control/joint_limits/test/joint_limits_rosparam.yaml --gtest_output=xml:/home/wrock/colcon_ws/build/joint_limits/test_results/joint_limits/joint_limits_rosparam_test.gtest.xml
    terminate called after throwing an instance of 'rclcpp::exceptions::UnknownROSArgsError'
      what():  found unknown ROS arguments: '--gtest_output=xml:/home/wrock/colcon_ws/build/joint_limits/test_results/joint_limits/joint_limits_rosparam_test.gtest.xml'
    -- run_test.py: return code -6
    -- run_test.py: generate result file '/home/wrock/colcon_ws/build/joint_limits/test_results/joint_limits/joint_limits_rosparam_test.gtest.xml' with failed test
    -- run_test.py: verify result file '/home/wrock/colcon_ws/build/joint_limits/test_results/joint_limits/joint_limits_rosparam_test.gtest.xml'
  >>>

With this change, the tests run successfully