### PR TITLE
standardize cmake

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.16)
 project(generate_parameter_library_example)
 
 find_package(ament_cmake REQUIRED)
@@ -29,20 +29,6 @@ rclcpp_components_register_node(minimal_publisher
   EXECUTABLE test_node
 )
 
-install(DIRECTORY include/ DESTINATION include/)
-install(TARGETS minimal_publisher admittance_controller_parameters
-  EXPORT generate_parameter_library_example_export
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
-)
-
-install(
-  TARGETS test_node
-  DESTINATION lib/${PROJECT_NAME}
-)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   set(ament_cmake_cpplint_FOUND TRUE) # Conflicts with clang-foramt
@@ -63,5 +49,24 @@ if(BUILD_TESTING)
   target_link_libraries(test_example_gmock admittance_controller_parameters rclcpp::rclcpp)
 endif()
 
-ament_export_targets(generate_parameter_library_example_export)
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(TARGETS minimal_publisher admittance_controller_parameters
+  EXPORT export_generate_parameter_library_example
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+install(
+  TARGETS test_node
+  DESTINATION lib/generate_parameter_library_example
+)
+
+ament_export_targets(export_generate_parameter_library_example HAS_LIBRARY_TARGET)
+ament_export_dependencies(rclcpp rclcpp_components)
 ament_package()

--- a/generate_parameter_library/CMakeLists.txt
+++ b/generate_parameter_library/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(ament_cmake REQUIRED)
 
 install(
   DIRECTORY cmake
-  DESTINATION share/${PROJECT_NAME}
+  DESTINATION share/generate_parameter_library
 )
 
 if(BUILD_TESTING)

--- a/generate_parameter_library/package.xml
+++ b/generate_parameter_library/package.xml
@@ -10,8 +10,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <buildtool_export_depend>generate_parameter_library_py</buildtool_export_depend>
+
   <depend>fmt</depend>
-  <depend>generate_parameter_library_py</depend>
   <depend>parameter_traits</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/parameter_traits/CMakeLists.txt
+++ b/parameter_traits/CMakeLists.txt
@@ -43,6 +43,6 @@ install(
   INCLUDES DESTINATION include
 )
 
-ament_export_targets(export_parameter_traits)
+ament_export_targets(export_parameter_traits HAS_LIBRARY_TARGET)
 ament_export_dependencies(fmt rclcpp tcb_span)
 ament_package()

--- a/parameter_traits/CMakeLists.txt
+++ b/parameter_traits/CMakeLists.txt
@@ -19,21 +19,6 @@ target_link_libraries(parameter_traits
     tcb_span::tcb_span
 )
 
-install(DIRECTORY include/ DESTINATION include/)
-
-install(
-  TARGETS parameter_traits
-  EXPORT parameter_traits
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
-)
-
-ament_export_include_directories(include)
-ament_export_targets(parameter_traits)
-ament_export_dependencies(fmt rclcpp tcb_span)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following lines skip linters
@@ -44,4 +29,20 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS parameter_traits
+  EXPORT export_parameter_traits
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+ament_export_targets(export_parameter_traits)
+ament_export_dependencies(fmt rclcpp tcb_span)
 ament_package()


### PR DESCRIPTION
- Remove superfluous call in cmake
- Buildtool export depend on python package
- Use package name instead of variable
- Standardize CMake in example
- parameter_traits HAS_LIBRARY_TARGE

Reference:
https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html#building-a-library
