### PR TITLE
Replace custom Result type with tl::expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+build
+log
+install

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,8 @@
+# Migration notes for generate_parameter_library
+
+0.2.6 to main
+-------------
+* Header `parameter_traits/result.hpp` removed, code moved into `parameter_traits/validators.hpp`
+* `parameter_traits::Result` renamed to `parameter_traits::ValidateResult`
+* `parameter_traits::ERROR` renamed to `parameter_traits::make_error`
+* `parameter_traits::OK` renamed to `parameter_traits::ok`

--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ The built-in validator functions provided by this package are:
 Validators are functions that return a `Result` type and accept a `rclcpp::Parameter const&` as their first argument and any number of arguments after that can be specified in YAML.
 Validators are C++ functions defined in a header file similar to the example shown below.
 
-The `Result` type has a alias `OK` that is shorthand for returning a successful validation.
-It also had a function `ERROR` that uses the expressive [fmt format](https://github.com/fmtlib/fmt) for constructing a human readable error.
+The `ValidateResult` type has a alias `ok` that is shorthand for returning a successful validation.
+It also had a function `make_error` that uses the expressive [fmt format](https://github.com/fmtlib/fmt) for constructing a human readable error.
 These come from the `parameter_traits` library.
 Note that you need to place your custom validators in the `parameter_traits` namespace.
 
@@ -263,14 +263,14 @@ Note that you need to place your custom validators in the `parameter_traits` nam
 
 namespace parameter_traits {
 
-Result integer_equal_value(rclcpp::Parameter const& parameter, int expected_value) {
+ValidateResult integer_equal_value(rclcpp::Parameter const& parameter, int expected_value) {
   int param_value = parameter.as_int();
     if (param_value != expected_value) {
-        return ERROR("Invalid value {} for parameter {}. Expected {}",
+        return make_error("Invalid value {} for parameter {}. Expected {}",
                param_value, parameter.get_name(), expected_value);
     }
 
-  return OK;
+  return ok();
 }
 
 }  // namespace parameter_traits

--- a/example/include/generate_parameter_library_example/example_validators.hpp
+++ b/example/include/generate_parameter_library_example/example_validators.hpp
@@ -33,29 +33,31 @@
 namespace parameter_traits {
 
 // User defined parameter validation
-Result validate_double_array_custom_func(const rclcpp::Parameter& parameter,
-                                         double max_sum, double max_element) {
+ValidateResult validate_double_array_custom_func(
+    const rclcpp::Parameter& parameter, double max_sum, double max_element) {
   const auto& double_array = parameter.as_double_array();
   double sum = 0.0;
   for (auto val : double_array) {
     sum += val;
     if (val > max_element) {
-      return ERROR(
+      return make_error(
           "The parameter contained an element greater than the max allowed "
           "value.  (%f) was greater than (%f)",
           val, max_element);
     }
   }
   if (sum > max_sum) {
-    return ERROR(
+    return make_error(
         "The sum of the parameter vector was greater than the max allowed "
         "value.  (%f) was greater than (%f)",
         sum, max_sum);
   }
 
-  return OK;
+  return ok();
 }
 
-Result no_args_validator(const rclcpp::Parameter& parameter) { return OK; }
+ValidateResult no_args_validator(const rclcpp::Parameter& parameter) {
+  return ok();
+}
 
 }  // namespace parameter_traits

--- a/generate_parameter_library/cmake/generate_parameter_library.cmake
+++ b/generate_parameter_library/cmake/generate_parameter_library.cmake
@@ -86,6 +86,7 @@ function(generate_parameter_library LIB_NAME YAML_FILE)
     rclcpp::rclcpp
     rclcpp_lifecycle::rclcpp_lifecycle
     tcb_span::tcb_span
+    tl_expected::tl_expected
   )
   install(DIRECTORY ${LIB_INCLUDE_DIR} DESTINATION include/)
 endfunction()

--- a/generate_parameter_library/generate_parameter_library-extras.cmake
+++ b/generate_parameter_library/generate_parameter_library-extras.cmake
@@ -31,5 +31,6 @@ find_package(parameter_traits REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(tcb_span REQUIRED)
+find_package(tl_expected REQUIRED)
 
 include("${generate_parameter_library_DIR}/generate_parameter_library.cmake")

--- a/generate_parameter_library/package.xml
+++ b/generate_parameter_library/package.xml
@@ -17,6 +17,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>tcb_span</depend>
+  <depend>tl_expected</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
@@ -118,7 +118,7 @@ struct StackParams {
 {%- endif %}
       updated_params.__stamp = clock_.now();
       update_interal_params(updated_params);
-      return parameter_traits::OK;
+      return parameter_traits::to_set_parameters_result(parameter_traits::ok());
     }
 
     void declare_params(){

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_validation
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_validation
@@ -1,5 +1,5 @@
 if(auto validation_result = parameter_traits::{{validation_function}};
-  !validation_result.success()) {
+  !validation_result) {
 {%- filter indent(width=4) %}
 {{invalid_effect}}
 {% endfilter -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/main.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/main.py
@@ -85,7 +85,7 @@ def initialization_fail_validation(param_name: str) -> str:
     return (
         f"throw rclcpp::exceptions::InvalidParameterValueException"
         f'(fmt::format("Invalid value set during initialization for '
-        f"parameter '{param_name}': \" + validation_result.error_msg()));"
+        f"parameter '{param_name}': \" + validation_result.error()));"
     )
 
 
@@ -96,7 +96,7 @@ def initialization_pass_validation(param_name: str, parameter_conversion: str) -
 
 @typechecked
 def update_parameter_fail_validation() -> str:
-    return "return validation_result;"
+    return "return parameter_traits::to_set_parameters_result(validation_result);"
 
 
 @typechecked

--- a/parameter_traits/CMakeLists.txt
+++ b/parameter_traits/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(ament_cmake REQUIRED)
 find_package(fmt REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tcb_span REQUIRED)
+find_package(tl_expected REQUIRED)
 
 add_library(parameter_traits INTERFACE)
 target_include_directories(parameter_traits INTERFACE
@@ -17,6 +18,7 @@ target_link_libraries(parameter_traits
     fmt::fmt
     rclcpp::rclcpp
     tcb_span::tcb_span
+    tl_expected::tl_expected
 )
 
 if(BUILD_TESTING)
@@ -44,5 +46,5 @@ install(
 )
 
 ament_export_targets(export_parameter_traits HAS_LIBRARY_TARGET)
-ament_export_dependencies(fmt rclcpp tcb_span)
+ament_export_dependencies(fmt rclcpp tcb_span tl_expected)
 ament_package()

--- a/parameter_traits/CMakeLists.txt
+++ b/parameter_traits/CMakeLists.txt
@@ -8,13 +8,15 @@ find_package(rclcpp REQUIRED)
 find_package(tcb_span REQUIRED)
 find_package(tl_expected REQUIRED)
 
-add_library(parameter_traits INTERFACE)
-target_include_directories(parameter_traits INTERFACE
+add_library(parameter_traits
+  src/validators.cpp
+)
+target_include_directories(parameter_traits PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_compile_features(parameter_traits INTERFACE cxx_std_17)
+target_compile_features(parameter_traits PUBLIC cxx_std_17)
 target_link_libraries(parameter_traits
-  INTERFACE
+  PUBLIC
     fmt::fmt
     rclcpp::rclcpp
     tcb_span::tcb_span

--- a/parameter_traits/include/parameter_traits/parameter_traits.hpp
+++ b/parameter_traits/include/parameter_traits/parameter_traits.hpp
@@ -30,5 +30,4 @@
 
 #include <parameter_traits/comparison.hpp>
 #include <parameter_traits/fixed_size_types.hpp>
-#include <parameter_traits/result.hpp>
 #include <parameter_traits/validators.hpp>

--- a/parameter_traits/include/parameter_traits/validators.hpp
+++ b/parameter_traits/include/parameter_traits/validators.hpp
@@ -42,8 +42,8 @@
 
 namespace parameter_traits {
 
-using ValidateResult = tl::expected<std::monostate, std::string>;
-using ok = std::monostate;
+using ValidateResult = tl::expected<void, std::string>;
+using ok = ValidateResult;
 
 template <typename... Args>
 ValidateResult make_error(std::string const& format, Args... args) {

--- a/parameter_traits/package.xml
+++ b/parameter_traits/package.xml
@@ -13,6 +13,7 @@
   <depend>fmt</depend>
   <depend>rclcpp</depend>
   <depend>tcb_span</depend>
+  <depend>tl_expected</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/parameter_traits/src/validators.cpp
+++ b/parameter_traits/src/validators.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, PickNik Inc.
+// Copyright 2022 PickNik Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,7 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 //
-//    * Neither the name of the copyright holder nor the names of its
+//    * Neither the name of the PickNik Inc. nor the names of its
 //      contributors may be used to endorse or promote products derived from
 //      this software without specific prior written permission.
 //
@@ -26,43 +26,17 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
-
-#include <string>
-
-#include <rclcpp/rclcpp.hpp>
-
-#include <fmt/format.h>
+#include <parameter_traits/validators.hpp>
+#include <rcl_interfaces/msg/set_parameters_result.hpp>
 
 namespace parameter_traits {
 
-class Result {
- public:
-  template <typename... Args>
-  Result(const std::string& format, Args... args) {
-    msg_ = fmt::format(format, args...);
-    success_ = false;
-  }
-
-  Result() = default;
-
-  operator rcl_interfaces::msg::SetParametersResult() const {
-    rcl_interfaces::msg::SetParametersResult result;
-    result.successful = success_;
-    result.reason = msg_;
-    return result;
-  }
-
-  bool success() { return success_; }
-
-  std::string error_msg() { return msg_; }
-
- private:
-  std::string msg_;
-  bool success_ = true;
-};
-
-auto static OK = Result();
-using ERROR = Result;
+rcl_interfaces::msg::SetParametersResult to_set_parameters_result(
+    ValidateResult const& res) {
+  rcl_interfaces::msg::SetParametersResult msg;
+  msg.successful = bool{res};
+  msg.reason = res ? "" : res.error();
+  return msg;
+}
 
 }  // namespace parameter_traits

--- a/parameter_traits/test/validators_tests.cpp
+++ b/parameter_traits/test/validators_tests.cpp
@@ -33,479 +33,384 @@
 
 #include <rclcpp/parameter.hpp>
 
-#include <parameter_traits/result.hpp>
 #include <parameter_traits/validators.hpp>
 
 namespace parameter_traits {
 using rclcpp::Parameter;
 
 TEST(ValidatorsTests, Bounds) {
-  EXPECT_TRUE(bounds<double>(Parameter{"", 1.0}, 1.0, 5.0).success());
-  EXPECT_TRUE(bounds<double>(Parameter{"", 4.3}, 1.0, 5.0).success());
-  EXPECT_TRUE(bounds<double>(Parameter{"", 5.0}, 1.0, 5.0).success());
-  EXPECT_FALSE(bounds<double>(Parameter{"", -4.3}, 1.0, 5.0).success());
-  EXPECT_FALSE(bounds<double>(Parameter{"", 10.2}, 1.0, 5.0).success());
+  EXPECT_TRUE(bounds<double>(Parameter{"", 1.0}, 1.0, 5.0));
+  EXPECT_TRUE(bounds<double>(Parameter{"", 4.3}, 1.0, 5.0));
+  EXPECT_TRUE(bounds<double>(Parameter{"", 5.0}, 1.0, 5.0));
+  EXPECT_FALSE(bounds<double>(Parameter{"", -4.3}, 1.0, 5.0));
+  EXPECT_FALSE(bounds<double>(Parameter{"", 10.2}, 1.0, 5.0));
 
-  EXPECT_TRUE(bounds<int64_t>(Parameter{"", 1}, 1, 5).success());
-  EXPECT_TRUE(bounds<int64_t>(Parameter{"", 4}, 1, 5).success());
-  EXPECT_TRUE(bounds<int64_t>(Parameter{"", 5}, 1, 5).success());
-  EXPECT_FALSE(bounds<int64_t>(Parameter{"", -4}, 1, 5).success());
-  EXPECT_FALSE(bounds<int64_t>(Parameter{"", 10}, 1, 5).success());
+  EXPECT_TRUE(bounds<int64_t>(Parameter{"", 1}, 1, 5));
+  EXPECT_TRUE(bounds<int64_t>(Parameter{"", 4}, 1, 5));
+  EXPECT_TRUE(bounds<int64_t>(Parameter{"", 5}, 1, 5));
+  EXPECT_FALSE(bounds<int64_t>(Parameter{"", -4}, 1, 5));
+  EXPECT_FALSE(bounds<int64_t>(Parameter{"", 10}, 1, 5));
 
-  EXPECT_TRUE(bounds<bool>(Parameter{"", true}, false, true).success());
-  EXPECT_FALSE(bounds<bool>(Parameter{"", false}, true, true).success());
-  EXPECT_FALSE(bounds<bool>(Parameter{"", true}, false, false).success());
+  EXPECT_TRUE(bounds<bool>(Parameter{"", true}, false, true));
+  EXPECT_FALSE(bounds<bool>(Parameter{"", false}, true, true));
+  EXPECT_FALSE(bounds<bool>(Parameter{"", true}, false, false));
 
   EXPECT_ANY_THROW(bounds<int64_t>(Parameter{"", ""}, 1, 5));
   EXPECT_ANY_THROW(bounds<std::string>(Parameter{"", 4}, "", "foo"));
 }
 
 TEST(ValidatorsTests, LowerBounds) {
-  EXPECT_TRUE(lower_bounds<double>(Parameter{"", 2.0}, 2.0).success());
-  EXPECT_TRUE(lower_bounds<double>(Parameter{"", 4.3}, 1.0).success());
-  EXPECT_FALSE(lower_bounds<double>(Parameter{"", -4.3}, 1.0).success());
+  EXPECT_TRUE(lower_bounds<double>(Parameter{"", 2.0}, 2.0));
+  EXPECT_TRUE(lower_bounds<double>(Parameter{"", 4.3}, 1.0));
+  EXPECT_FALSE(lower_bounds<double>(Parameter{"", -4.3}, 1.0));
 
-  EXPECT_TRUE(lower_bounds<int64_t>(Parameter{"", 1}, 1).success());
-  EXPECT_TRUE(lower_bounds<int64_t>(Parameter{"", 4}, 1).success());
-  EXPECT_FALSE(lower_bounds<int64_t>(Parameter{"", -4}, 1).success());
+  EXPECT_TRUE(lower_bounds<int64_t>(Parameter{"", 1}, 1));
+  EXPECT_TRUE(lower_bounds<int64_t>(Parameter{"", 4}, 1));
+  EXPECT_FALSE(lower_bounds<int64_t>(Parameter{"", -4}, 1));
 
-  EXPECT_TRUE(lower_bounds<bool>(Parameter{"", true}, false).success());
-  EXPECT_FALSE(lower_bounds<bool>(Parameter{"", false}, true).success());
-  EXPECT_TRUE(lower_bounds<bool>(Parameter{"", true}, true).success());
+  EXPECT_TRUE(lower_bounds<bool>(Parameter{"", true}, false));
+  EXPECT_FALSE(lower_bounds<bool>(Parameter{"", false}, true));
+  EXPECT_TRUE(lower_bounds<bool>(Parameter{"", true}, true));
 }
 
 TEST(ValidatorsTests, UpperBounds) {
-  EXPECT_TRUE(upper_bounds<double>(Parameter{"", 2.0}, 2.0).success());
-  EXPECT_FALSE(upper_bounds<double>(Parameter{"", 4.3}, 1.0).success());
-  EXPECT_TRUE(upper_bounds<double>(Parameter{"", -4.3}, 1.0).success());
+  EXPECT_TRUE(upper_bounds<double>(Parameter{"", 2.0}, 2.0));
+  EXPECT_FALSE(upper_bounds<double>(Parameter{"", 4.3}, 1.0));
+  EXPECT_TRUE(upper_bounds<double>(Parameter{"", -4.3}, 1.0));
 
-  EXPECT_TRUE(upper_bounds<int64_t>(Parameter{"", 1}, 1).success());
-  EXPECT_FALSE(upper_bounds<int64_t>(Parameter{"", 4}, 1).success());
-  EXPECT_TRUE(upper_bounds<int64_t>(Parameter{"", -4}, 1).success());
+  EXPECT_TRUE(upper_bounds<int64_t>(Parameter{"", 1}, 1));
+  EXPECT_FALSE(upper_bounds<int64_t>(Parameter{"", 4}, 1));
+  EXPECT_TRUE(upper_bounds<int64_t>(Parameter{"", -4}, 1));
 
-  EXPECT_FALSE(upper_bounds<bool>(Parameter{"", true}, false).success());
-  EXPECT_TRUE(upper_bounds<bool>(Parameter{"", false}, true).success());
-  EXPECT_TRUE(upper_bounds<bool>(Parameter{"", true}, true).success());
+  EXPECT_FALSE(upper_bounds<bool>(Parameter{"", true}, false));
+  EXPECT_TRUE(upper_bounds<bool>(Parameter{"", false}, true));
+  EXPECT_TRUE(upper_bounds<bool>(Parameter{"", true}, true));
 }
 
 TEST(ValidatorsTests, GreaterThan) {
-  EXPECT_FALSE(gt<double>(Parameter{"", 2.0}, 2.0).success());
-  EXPECT_TRUE(gt<double>(Parameter{"", 4.3}, 1.0).success());
-  EXPECT_FALSE(gt<double>(Parameter{"", -4.3}, 1.0).success());
+  EXPECT_FALSE(gt<double>(Parameter{"", 2.0}, 2.0));
+  EXPECT_TRUE(gt<double>(Parameter{"", 4.3}, 1.0));
+  EXPECT_FALSE(gt<double>(Parameter{"", -4.3}, 1.0));
 
-  EXPECT_FALSE(gt<int64_t>(Parameter{"", 1}, 1).success());
-  EXPECT_TRUE(gt<int64_t>(Parameter{"", 4}, 1).success());
-  EXPECT_FALSE(gt<int64_t>(Parameter{"", -4}, 1).success());
+  EXPECT_FALSE(gt<int64_t>(Parameter{"", 1}, 1));
+  EXPECT_TRUE(gt<int64_t>(Parameter{"", 4}, 1));
+  EXPECT_FALSE(gt<int64_t>(Parameter{"", -4}, 1));
 
-  EXPECT_TRUE(gt<bool>(Parameter{"", true}, false).success());
-  EXPECT_FALSE(gt<bool>(Parameter{"", false}, true).success());
-  EXPECT_FALSE(gt<bool>(Parameter{"", true}, true).success());
+  EXPECT_TRUE(gt<bool>(Parameter{"", true}, false));
+  EXPECT_FALSE(gt<bool>(Parameter{"", false}, true));
+  EXPECT_FALSE(gt<bool>(Parameter{"", true}, true));
 }
 
 TEST(ValidatorsTests, LessThan) {
-  EXPECT_FALSE(lt<double>(Parameter{"", 2.0}, 2.0).success());
-  EXPECT_FALSE(lt<double>(Parameter{"", 4.3}, 1.0).success());
-  EXPECT_TRUE(lt<double>(Parameter{"", -4.3}, 1.0).success());
+  EXPECT_FALSE(lt<double>(Parameter{"", 2.0}, 2.0));
+  EXPECT_FALSE(lt<double>(Parameter{"", 4.3}, 1.0));
+  EXPECT_TRUE(lt<double>(Parameter{"", -4.3}, 1.0));
 
-  EXPECT_FALSE(lt<int64_t>(Parameter{"", 1}, 1).success());
-  EXPECT_FALSE(lt<int64_t>(Parameter{"", 4}, 1).success());
-  EXPECT_TRUE(lt<int64_t>(Parameter{"", -4}, 1).success());
+  EXPECT_FALSE(lt<int64_t>(Parameter{"", 1}, 1));
+  EXPECT_FALSE(lt<int64_t>(Parameter{"", 4}, 1));
+  EXPECT_TRUE(lt<int64_t>(Parameter{"", -4}, 1));
 
-  EXPECT_FALSE(lt<bool>(Parameter{"", true}, false).success());
-  EXPECT_TRUE(lt<bool>(Parameter{"", false}, true).success());
-  EXPECT_FALSE(lt<bool>(Parameter{"", true}, true).success());
+  EXPECT_FALSE(lt<bool>(Parameter{"", true}, false));
+  EXPECT_TRUE(lt<bool>(Parameter{"", false}, true));
+  EXPECT_FALSE(lt<bool>(Parameter{"", true}, true));
 }
 
 TEST(ValidatorsTests, GreaterThanOrEqual) {
-  EXPECT_TRUE(gt_eq<double>(Parameter{"", 2.0}, 2.0).success());
-  EXPECT_TRUE(gt_eq<double>(Parameter{"", 4.3}, 1.0).success());
-  EXPECT_FALSE(gt_eq<double>(Parameter{"", -4.3}, 1.0).success());
+  EXPECT_TRUE(gt_eq<double>(Parameter{"", 2.0}, 2.0));
+  EXPECT_TRUE(gt_eq<double>(Parameter{"", 4.3}, 1.0));
+  EXPECT_FALSE(gt_eq<double>(Parameter{"", -4.3}, 1.0));
 
-  EXPECT_TRUE(gt_eq<int64_t>(Parameter{"", 1}, 1).success());
-  EXPECT_TRUE(gt_eq<int64_t>(Parameter{"", 4}, 1).success());
-  EXPECT_FALSE(gt_eq<int64_t>(Parameter{"", -4}, 1).success());
+  EXPECT_TRUE(gt_eq<int64_t>(Parameter{"", 1}, 1));
+  EXPECT_TRUE(gt_eq<int64_t>(Parameter{"", 4}, 1));
+  EXPECT_FALSE(gt_eq<int64_t>(Parameter{"", -4}, 1));
 
-  EXPECT_TRUE(gt_eq<bool>(Parameter{"", true}, false).success());
-  EXPECT_FALSE(gt_eq<bool>(Parameter{"", false}, true).success());
-  EXPECT_TRUE(gt_eq<bool>(Parameter{"", true}, true).success());
+  EXPECT_TRUE(gt_eq<bool>(Parameter{"", true}, false));
+  EXPECT_FALSE(gt_eq<bool>(Parameter{"", false}, true));
+  EXPECT_TRUE(gt_eq<bool>(Parameter{"", true}, true));
 }
 
 TEST(ValidatorsTests, LessThanOrEqual) {
-  EXPECT_TRUE(lt_eq<double>(Parameter{"", 2.0}, 2.0).success());
-  EXPECT_FALSE(lt_eq<double>(Parameter{"", 4.3}, 1.0).success());
-  EXPECT_TRUE(lt_eq<double>(Parameter{"", -4.3}, 1.0).success());
+  EXPECT_TRUE(lt_eq<double>(Parameter{"", 2.0}, 2.0));
+  EXPECT_FALSE(lt_eq<double>(Parameter{"", 4.3}, 1.0));
+  EXPECT_TRUE(lt_eq<double>(Parameter{"", -4.3}, 1.0));
 
-  EXPECT_TRUE(lt_eq<int64_t>(Parameter{"", 1}, 1).success());
-  EXPECT_FALSE(lt_eq<int64_t>(Parameter{"", 4}, 1).success());
-  EXPECT_TRUE(lt_eq<int64_t>(Parameter{"", -4}, 1).success());
+  EXPECT_TRUE(lt_eq<int64_t>(Parameter{"", 1}, 1));
+  EXPECT_FALSE(lt_eq<int64_t>(Parameter{"", 4}, 1));
+  EXPECT_TRUE(lt_eq<int64_t>(Parameter{"", -4}, 1));
 
-  EXPECT_FALSE(lt_eq<bool>(Parameter{"", true}, false).success());
-  EXPECT_TRUE(lt_eq<bool>(Parameter{"", false}, true).success());
-  EXPECT_TRUE(lt_eq<bool>(Parameter{"", true}, true).success());
+  EXPECT_FALSE(lt_eq<bool>(Parameter{"", true}, false));
+  EXPECT_TRUE(lt_eq<bool>(Parameter{"", false}, true));
+  EXPECT_TRUE(lt_eq<bool>(Parameter{"", true}, true));
 }
 
 TEST(ValidatorsTests, OneOf) {
+  EXPECT_TRUE(one_of<double>(Parameter{"", 2.0}, std::vector<double>{2.0}));
   EXPECT_TRUE(
-      one_of<double>(Parameter{"", 2.0}, std::vector<double>{2.0}).success());
-  EXPECT_TRUE(
-      one_of<double>(Parameter{"", 2.0}, std::vector<double>{1.0, 2.0, 3.5})
-          .success());
+      one_of<double>(Parameter{"", 2.0}, std::vector<double>{1.0, 2.0, 3.5}));
   EXPECT_FALSE(
-      one_of<double>(Parameter{"", 0.0}, std::vector<double>{1.0, 2.0, 3.5})
-          .success());
-  EXPECT_FALSE(
-      one_of<double>(Parameter{"", 0.0}, std::vector<double>{}).success());
+      one_of<double>(Parameter{"", 0.0}, std::vector<double>{1.0, 2.0, 3.5}));
+  EXPECT_FALSE(one_of<double>(Parameter{"", 0.0}, std::vector<double>{}));
 
+  EXPECT_TRUE(one_of<int64_t>(Parameter{"", 1}, std::vector<int64_t>{1}));
   EXPECT_TRUE(
-      one_of<int64_t>(Parameter{"", 1}, std::vector<int64_t>{1}).success());
-  EXPECT_TRUE(
-      one_of<int64_t>(Parameter{"", 1}, std::vector<int64_t>{1, 2, 3, 4})
-          .success());
+      one_of<int64_t>(Parameter{"", 1}, std::vector<int64_t>{1, 2, 3, 4}));
   EXPECT_FALSE(
-      one_of<int64_t>(Parameter{"", 0}, std::vector<int64_t>{1, 2, 3, 4})
-          .success());
-  EXPECT_FALSE(
-      one_of<int64_t>(Parameter{"", 0}, std::vector<int64_t>{}).success());
+      one_of<int64_t>(Parameter{"", 0}, std::vector<int64_t>{1, 2, 3, 4}));
+  EXPECT_FALSE(one_of<int64_t>(Parameter{"", 0}, std::vector<int64_t>{}));
 
-  EXPECT_FALSE(
-      one_of<bool>(Parameter{"", true}, std::vector<bool>{false}).success());
-  EXPECT_TRUE(one_of<bool>(Parameter{"", true}, std::vector<bool>{false, true})
-                  .success());
+  EXPECT_FALSE(one_of<bool>(Parameter{"", true}, std::vector<bool>{false}));
   EXPECT_TRUE(
-      one_of<bool>(Parameter{"", true}, std::vector<bool>{true}).success());
-  EXPECT_FALSE(
-      one_of<bool>(Parameter{"", true}, std::vector<bool>{}).success());
+      one_of<bool>(Parameter{"", true}, std::vector<bool>{false, true}));
+  EXPECT_TRUE(one_of<bool>(Parameter{"", true}, std::vector<bool>{true}));
+  EXPECT_FALSE(one_of<bool>(Parameter{"", true}, std::vector<bool>{}));
 }
 
 TEST(ValidatorsTests, FixedSizeString) {
-  EXPECT_TRUE(fixed_size<std::string>(Parameter{"", "foo"}, 3).success());
-  EXPECT_TRUE(fixed_size<std::string>(Parameter{"", ""}, 0).success());
-  EXPECT_FALSE(fixed_size<std::string>(Parameter{"", "foo"}, 0).success());
-  EXPECT_FALSE(fixed_size<std::string>(Parameter{"", "foo"}, 5).success());
+  EXPECT_TRUE(fixed_size<std::string>(Parameter{"", "foo"}, 3));
+  EXPECT_TRUE(fixed_size<std::string>(Parameter{"", ""}, 0));
+  EXPECT_FALSE(fixed_size<std::string>(Parameter{"", "foo"}, 0));
+  EXPECT_FALSE(fixed_size<std::string>(Parameter{"", "foo"}, 5));
 }
 
 TEST(ValidatorsTests, SizeGtString) {
-  EXPECT_TRUE(size_gt<std::string>(Parameter{"", "foo"}, 2).success());
-  EXPECT_FALSE(size_gt<std::string>(Parameter{"", ""}, 0).success());
-  EXPECT_FALSE(size_gt<std::string>(Parameter{"", "foo"}, 5).success());
+  EXPECT_TRUE(size_gt<std::string>(Parameter{"", "foo"}, 2));
+  EXPECT_FALSE(size_gt<std::string>(Parameter{"", ""}, 0));
+  EXPECT_FALSE(size_gt<std::string>(Parameter{"", "foo"}, 5));
 }
 
 TEST(ValidatorsTests, SizeLtString) {
-  EXPECT_TRUE(size_lt<std::string>(Parameter{"", "foo"}, 5).success());
-  EXPECT_FALSE(size_lt<std::string>(Parameter{"", ""}, 0).success());
-  EXPECT_FALSE(size_lt<std::string>(Parameter{"", "foo"}, 3).success());
+  EXPECT_TRUE(size_lt<std::string>(Parameter{"", "foo"}, 5));
+  EXPECT_FALSE(size_lt<std::string>(Parameter{"", ""}, 0));
+  EXPECT_FALSE(size_lt<std::string>(Parameter{"", "foo"}, 3));
 }
 
 TEST(ValidatorsTests, NotEmptyString) {
-  EXPECT_TRUE(not_empty<std::string>(Parameter{"", "foo"}).success());
-  EXPECT_FALSE(not_empty<std::string>(Parameter{"", ""}).success());
+  EXPECT_TRUE(not_empty<std::string>(Parameter{"", "foo"}));
+  EXPECT_FALSE(not_empty<std::string>(Parameter{"", ""}));
 }
 
 TEST(ValidatorsTests, OneOfString) {
   EXPECT_TRUE(one_of<std::string>(Parameter{"", "foo"},
-                                  std::vector<std::string>{"foo", "baz"})
-                  .success());
+                                  std::vector<std::string>{"foo", "baz"}));
   EXPECT_FALSE(one_of<std::string>(Parameter{"", ""},
-                                   std::vector<std::string>{"foo", "baz"})
-                   .success());
+                                   std::vector<std::string>{"foo", "baz"}));
 }
 
 TEST(ValidatorsTests, UniqueArray) {
-  EXPECT_TRUE(
-      unique<std::string>(Parameter{"", std::vector<std::string>{"", "1", "2"}})
-          .success());
-  EXPECT_TRUE(
-      unique<std::string>(Parameter{"", std::vector<std::string>{}}).success());
-  EXPECT_FALSE(
-      unique<std::string>(Parameter{"", std::vector<std::string>{"foo", "foo"}})
-          .success());
-
-  EXPECT_TRUE(unique<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}})
-                  .success());
-  EXPECT_TRUE(unique<double>(Parameter{"", std::vector<double>{}}).success());
-  EXPECT_FALSE(
-      unique<double>(Parameter{"", std::vector<double>{1.1, 1.1}}).success());
+  EXPECT_TRUE(unique<std::string>(
+      Parameter{"", std::vector<std::string>{"", "1", "2"}}));
+  EXPECT_TRUE(unique<std::string>(Parameter{"", std::vector<std::string>{}}));
+  EXPECT_FALSE(unique<std::string>(
+      Parameter{"", std::vector<std::string>{"foo", "foo"}}));
 
   EXPECT_TRUE(
-      unique<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}).success());
-  EXPECT_TRUE(unique<int64_t>(Parameter{"", std::vector<int64_t>{}}).success());
-  EXPECT_FALSE(
-      unique<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}).success());
+      unique<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}));
+  EXPECT_TRUE(unique<double>(Parameter{"", std::vector<double>{}}));
+  EXPECT_FALSE(unique<double>(Parameter{"", std::vector<double>{1.1, 1.1}}));
 
-  EXPECT_TRUE(
-      unique<bool>(Parameter{"", std::vector<bool>{true, false}}).success());
-  EXPECT_TRUE(unique<bool>(Parameter{"", std::vector<bool>{}}).success());
-  EXPECT_FALSE(
-      unique<bool>(Parameter{"", std::vector<bool>{false, false}}).success());
+  EXPECT_TRUE(unique<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}));
+  EXPECT_TRUE(unique<int64_t>(Parameter{"", std::vector<int64_t>{}}));
+  EXPECT_FALSE(unique<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}));
+
+  EXPECT_TRUE(unique<bool>(Parameter{"", std::vector<bool>{true, false}}));
+  EXPECT_TRUE(unique<bool>(Parameter{"", std::vector<bool>{}}));
+  EXPECT_FALSE(unique<bool>(Parameter{"", std::vector<bool>{false, false}}));
 }
 
 TEST(ValidatorsTests, SubsetOfArray) {
   EXPECT_TRUE(subset_of<std::string>(
-                  Parameter{"", std::vector<std::string>{"", "1", "2"}},
-                  std::vector<std::string>{"", "1", "2", "three"})
-                  .success());
+      Parameter{"", std::vector<std::string>{"", "1", "2"}},
+      std::vector<std::string>{"", "1", "2", "three"}));
   EXPECT_TRUE(
       subset_of<std::string>(Parameter{"", std::vector<std::string>{}},
-                             std::vector<std::string>{"", "1", "2", "three"})
-          .success());
+                             std::vector<std::string>{"", "1", "2", "three"}));
   EXPECT_FALSE(subset_of<std::string>(
-                   Parameter{"", std::vector<std::string>{"foo", "foo"}},
-                   std::vector<std::string>{"", "1", "2", "three"})
-                   .success());
+      Parameter{"", std::vector<std::string>{"foo", "foo"}},
+      std::vector<std::string>{"", "1", "2", "three"}));
 
   EXPECT_TRUE(
       subset_of<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}},
-                        std::vector<double>{1.0, 2.2, 1.1})
-          .success());
+                        std::vector<double>{1.0, 2.2, 1.1}));
   EXPECT_TRUE(subset_of<double>(Parameter{"", std::vector<double>{}},
-                                std::vector<double>{10, 22})
-                  .success());
+                                std::vector<double>{10, 22}));
   EXPECT_FALSE(subset_of<double>(Parameter{"", std::vector<double>{1.1, 1.1}},
-                                 std::vector<double>{1.0, 2.2})
-                   .success());
+                                 std::vector<double>{1.0, 2.2}));
 
   EXPECT_TRUE(subset_of<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}},
-                                 std::vector<int64_t>{1, 2, 3})
-                  .success());
+                                 std::vector<int64_t>{1, 2, 3}));
   EXPECT_TRUE(subset_of<int64_t>(Parameter{"", std::vector<int64_t>{}},
-                                 std::vector<int64_t>{1, 2, 3})
-                  .success());
+                                 std::vector<int64_t>{1, 2, 3}));
   EXPECT_FALSE(subset_of<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}},
-                                  std::vector<int64_t>{1, 2, 3})
-                   .success());
+                                  std::vector<int64_t>{1, 2, 3}));
 
   EXPECT_TRUE(subset_of<bool>(Parameter{"", std::vector<bool>{true, false}},
-                              std::vector<bool>{true, false})
-                  .success());
+                              std::vector<bool>{true, false}));
   EXPECT_TRUE(subset_of<bool>(Parameter{"", std::vector<bool>{}},
-                              std::vector<bool>{true, false})
-                  .success());
+                              std::vector<bool>{true, false}));
   EXPECT_FALSE(subset_of<bool>(Parameter{"", std::vector<bool>{false, false}},
-                               std::vector<bool>{true})
-                   .success());
+                               std::vector<bool>{true}));
 }
 
 TEST(ValidatorsTests, FixedSizeArray) {
   EXPECT_TRUE(fixed_size<std::string>(
-                  Parameter{"", std::vector<std::string>{"", "1", "2"}}, 3)
-                  .success());
+      Parameter{"", std::vector<std::string>{"", "1", "2"}}, 3));
   EXPECT_TRUE(
-      fixed_size<std::string>(Parameter{"", std::vector<std::string>{}}, 0)
-          .success());
+      fixed_size<std::string>(Parameter{"", std::vector<std::string>{}}, 0));
   EXPECT_FALSE(fixed_size<std::string>(
-                   Parameter{"", std::vector<std::string>{"foo", "foo"}}, 3)
-                   .success());
+      Parameter{"", std::vector<std::string>{"foo", "foo"}}, 3));
 
   EXPECT_TRUE(
-      fixed_size<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 3)
-          .success());
-  EXPECT_TRUE(
-      fixed_size<double>(Parameter{"", std::vector<double>{}}, 0).success());
+      fixed_size<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 3));
+  EXPECT_TRUE(fixed_size<double>(Parameter{"", std::vector<double>{}}, 0));
   EXPECT_FALSE(
-      fixed_size<double>(Parameter{"", std::vector<double>{1.1, 1.1}}, 3)
-          .success());
+      fixed_size<double>(Parameter{"", std::vector<double>{1.1, 1.1}}, 3));
 
   EXPECT_TRUE(
-      fixed_size<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}, 3)
-          .success());
-  EXPECT_TRUE(
-      fixed_size<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0).success());
+      fixed_size<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}, 3));
+  EXPECT_TRUE(fixed_size<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0));
   EXPECT_FALSE(
-      fixed_size<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}, 0)
-          .success());
+      fixed_size<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}, 0));
 
-  EXPECT_TRUE(fixed_size<bool>(Parameter{"", std::vector<bool>{true, false}}, 2)
-                  .success());
   EXPECT_TRUE(
-      fixed_size<bool>(Parameter{"", std::vector<bool>{}}, 0).success());
+      fixed_size<bool>(Parameter{"", std::vector<bool>{true, false}}, 2));
+  EXPECT_TRUE(fixed_size<bool>(Parameter{"", std::vector<bool>{}}, 0));
   EXPECT_FALSE(
-      fixed_size<bool>(Parameter{"", std::vector<bool>{false, false}}, 0)
-          .success());
+      fixed_size<bool>(Parameter{"", std::vector<bool>{false, false}}, 0));
 }
 
 TEST(ValidatorsTests, SizeGtArray) {
   EXPECT_TRUE(size_gt<std::string>(
-                  Parameter{"", std::vector<std::string>{"", "1", "2"}}, 1)
-                  .success());
+      Parameter{"", std::vector<std::string>{"", "1", "2"}}, 1));
   EXPECT_FALSE(
-      size_gt<std::string>(Parameter{"", std::vector<std::string>{}}, 0)
-          .success());
+      size_gt<std::string>(Parameter{"", std::vector<std::string>{}}, 0));
   EXPECT_FALSE(size_gt<std::string>(
-                   Parameter{"", std::vector<std::string>{"foo", "foo"}}, 3)
-                   .success());
+      Parameter{"", std::vector<std::string>{"foo", "foo"}}, 3));
 
   EXPECT_TRUE(
-      size_gt<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 2)
-          .success());
+      size_gt<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 2));
+  EXPECT_FALSE(size_gt<double>(Parameter{"", std::vector<double>{}}, 0));
   EXPECT_FALSE(
-      size_gt<double>(Parameter{"", std::vector<double>{}}, 0).success());
-  EXPECT_FALSE(size_gt<double>(Parameter{"", std::vector<double>{1.1, 1.1}}, 3)
-                   .success());
+      size_gt<double>(Parameter{"", std::vector<double>{1.1, 1.1}}, 3));
 
-  EXPECT_TRUE(size_gt<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}, 2)
-                  .success());
-  EXPECT_FALSE(
-      size_gt<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0).success());
-  EXPECT_TRUE(size_gt<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}, 0)
-                  .success());
+  EXPECT_TRUE(
+      size_gt<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}, 2));
+  EXPECT_FALSE(size_gt<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0));
+  EXPECT_TRUE(size_gt<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}, 0));
 
-  EXPECT_TRUE(size_gt<bool>(Parameter{"", std::vector<bool>{true, false}}, 0)
-                  .success());
-  EXPECT_FALSE(size_gt<bool>(Parameter{"", std::vector<bool>{}}, 0).success());
-  EXPECT_TRUE(size_gt<bool>(Parameter{"", std::vector<bool>{false, false}}, 0)
-                  .success());
+  EXPECT_TRUE(size_gt<bool>(Parameter{"", std::vector<bool>{true, false}}, 0));
+  EXPECT_FALSE(size_gt<bool>(Parameter{"", std::vector<bool>{}}, 0));
+  EXPECT_TRUE(size_gt<bool>(Parameter{"", std::vector<bool>{false, false}}, 0));
 }
 
 TEST(ValidatorsTests, SizeLtArray) {
   EXPECT_FALSE(size_lt<std::string>(
-                   Parameter{"", std::vector<std::string>{"", "1", "2"}}, 1)
-                   .success());
+      Parameter{"", std::vector<std::string>{"", "1", "2"}}, 1));
   EXPECT_FALSE(
-      size_lt<std::string>(Parameter{"", std::vector<std::string>{}}, 0)
-          .success());
+      size_lt<std::string>(Parameter{"", std::vector<std::string>{}}, 0));
   EXPECT_TRUE(size_lt<std::string>(
-                  Parameter{"", std::vector<std::string>{"foo", "foo"}}, 3)
-                  .success());
+      Parameter{"", std::vector<std::string>{"foo", "foo"}}, 3));
 
   EXPECT_FALSE(
-      size_lt<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 2)
-          .success());
-  EXPECT_FALSE(
-      size_lt<double>(Parameter{"", std::vector<double>{}}, 0).success());
-  EXPECT_TRUE(size_lt<double>(Parameter{"", std::vector<double>{1.1, 1.1}}, 3)
-                  .success());
+      size_lt<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 2));
+  EXPECT_FALSE(size_lt<double>(Parameter{"", std::vector<double>{}}, 0));
+  EXPECT_TRUE(size_lt<double>(Parameter{"", std::vector<double>{1.1, 1.1}}, 3));
 
-  EXPECT_FALSE(size_lt<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}, 2)
-                   .success());
   EXPECT_FALSE(
-      size_lt<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0).success());
-  EXPECT_FALSE(size_lt<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}, 0)
-                   .success());
+      size_lt<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}, 2));
+  EXPECT_FALSE(size_lt<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0));
+  EXPECT_FALSE(
+      size_lt<int64_t>(Parameter{"", std::vector<int64_t>{-1, -1}}, 0));
 
-  EXPECT_TRUE(size_lt<bool>(Parameter{"", std::vector<bool>{true, false}}, 3)
-                  .success());
-  EXPECT_FALSE(size_lt<bool>(Parameter{"", std::vector<bool>{}}, 0).success());
-  EXPECT_FALSE(size_lt<bool>(Parameter{"", std::vector<bool>{false, false}}, 0)
-                   .success());
+  EXPECT_TRUE(size_lt<bool>(Parameter{"", std::vector<bool>{true, false}}, 3));
+  EXPECT_FALSE(size_lt<bool>(Parameter{"", std::vector<bool>{}}, 0));
+  EXPECT_FALSE(
+      size_lt<bool>(Parameter{"", std::vector<bool>{false, false}}, 0));
 }
 
 TEST(ValidatorsTests, NotEmptyArray) {
   EXPECT_TRUE(not_empty<std::string>(
-                  Parameter{"", std::vector<std::string>{"", "1", "2"}})
-                  .success());
-  EXPECT_FALSE(not_empty<std::string>(Parameter{"", std::vector<std::string>{}})
-                   .success());
+      Parameter{"", std::vector<std::string>{"", "1", "2"}}));
+  EXPECT_FALSE(
+      not_empty<std::string>(Parameter{"", std::vector<std::string>{}}));
 
   EXPECT_TRUE(
-      not_empty<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}})
-          .success());
-  EXPECT_FALSE(
-      not_empty<double>(Parameter{"", std::vector<double>{}}).success());
+      not_empty<double>(Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}));
+  EXPECT_FALSE(not_empty<double>(Parameter{"", std::vector<double>{}}));
 
-  EXPECT_TRUE(not_empty<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}})
-                  .success());
-  EXPECT_FALSE(
-      not_empty<int64_t>(Parameter{"", std::vector<int64_t>{}}).success());
+  EXPECT_TRUE(not_empty<int64_t>(Parameter{"", std::vector<int64_t>{1, 2, 3}}));
+  EXPECT_FALSE(not_empty<int64_t>(Parameter{"", std::vector<int64_t>{}}));
 
-  EXPECT_TRUE(
-      not_empty<bool>(Parameter{"", std::vector<bool>{true, false}}).success());
-  EXPECT_FALSE(not_empty<bool>(Parameter{"", std::vector<bool>{}}).success());
+  EXPECT_TRUE(not_empty<bool>(Parameter{"", std::vector<bool>{true, false}}));
+  EXPECT_FALSE(not_empty<bool>(Parameter{"", std::vector<bool>{}}));
 }
 
 TEST(ValidatorsTests, ElementBoundsArray) {
   EXPECT_TRUE(element_bounds<double>(
-                  Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 0.0, 3.0)
-                  .success());
+      Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 0.0, 3.0));
   EXPECT_TRUE(
-      element_bounds<double>(Parameter{"", std::vector<double>{}}, 0.0, 1.0)
-          .success());
+      element_bounds<double>(Parameter{"", std::vector<double>{}}, 0.0, 1.0));
 
   EXPECT_TRUE(element_bounds<int64_t>(
-                  Parameter{"", std::vector<int64_t>{1, 2, 3}}, 0, 5)
-                  .success());
+      Parameter{"", std::vector<int64_t>{1, 2, 3}}, 0, 5));
   EXPECT_FALSE(element_bounds<int64_t>(
-                   Parameter{"", std::vector<int64_t>{1, 2, 3}}, -5, 0)
-                   .success());
+      Parameter{"", std::vector<int64_t>{1, 2, 3}}, -5, 0));
   EXPECT_TRUE(
-      element_bounds<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0, 1)
-          .success());
+      element_bounds<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0, 1));
 
   EXPECT_TRUE(element_bounds<bool>(
-                  Parameter{"", std::vector<bool>{true, false}}, false, true)
-                  .success());
+      Parameter{"", std::vector<bool>{true, false}}, false, true));
   EXPECT_FALSE(element_bounds<bool>(
-                   Parameter{"", std::vector<bool>{true, false}}, true, false)
-                   .success());
+      Parameter{"", std::vector<bool>{true, false}}, true, false));
   EXPECT_FALSE(element_bounds<bool>(
-                   Parameter{"", std::vector<bool>{true, false}}, false, false)
-                   .success());
+      Parameter{"", std::vector<bool>{true, false}}, false, false));
   EXPECT_TRUE(
-      element_bounds<bool>(Parameter{"", std::vector<bool>{}}, true, false)
-          .success());
+      element_bounds<bool>(Parameter{"", std::vector<bool>{}}, true, false));
 }
 
 TEST(ValidatorsTests, LowerElementBoundsArray) {
   EXPECT_TRUE(lower_element_bounds<double>(
-                  Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 0.0)
-                  .success());
+      Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 0.0));
   EXPECT_TRUE(
-      lower_element_bounds<double>(Parameter{"", std::vector<double>{}}, 0.0)
-          .success());
+      lower_element_bounds<double>(Parameter{"", std::vector<double>{}}, 0.0));
 
   EXPECT_TRUE(lower_element_bounds<int64_t>(
-                  Parameter{"", std::vector<int64_t>{1, 2, 3}}, 0)
-                  .success());
+      Parameter{"", std::vector<int64_t>{1, 2, 3}}, 0));
   EXPECT_FALSE(lower_element_bounds<int64_t>(
-                   Parameter{"", std::vector<int64_t>{1, 2, 3}}, 3)
-                   .success());
+      Parameter{"", std::vector<int64_t>{1, 2, 3}}, 3));
   EXPECT_TRUE(
-      lower_element_bounds<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0)
-          .success());
+      lower_element_bounds<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0));
 
   EXPECT_TRUE(lower_element_bounds<bool>(
-                  Parameter{"", std::vector<bool>{true, false}}, false)
-                  .success());
+      Parameter{"", std::vector<bool>{true, false}}, false));
   EXPECT_FALSE(lower_element_bounds<bool>(
-                   Parameter{"", std::vector<bool>{true, false}}, true)
-                   .success());
+      Parameter{"", std::vector<bool>{true, false}}, true));
   EXPECT_TRUE(lower_element_bounds<bool>(
-                  Parameter{"", std::vector<bool>{true, false}}, false)
-                  .success());
+      Parameter{"", std::vector<bool>{true, false}}, false));
   EXPECT_TRUE(
-      lower_element_bounds<bool>(Parameter{"", std::vector<bool>{}}, true)
-          .success());
+      lower_element_bounds<bool>(Parameter{"", std::vector<bool>{}}, true));
 }
 
 TEST(ValidatorsTests, UpperElementBoundsArray) {
   EXPECT_FALSE(upper_element_bounds<double>(
-                   Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 0.0)
-                   .success());
+      Parameter{"", std::vector<double>{1.0, 2.2, 1.1}}, 0.0));
   EXPECT_TRUE(
-      upper_element_bounds<double>(Parameter{"", std::vector<double>{}}, 0.0)
-          .success());
+      upper_element_bounds<double>(Parameter{"", std::vector<double>{}}, 0.0));
 
   EXPECT_FALSE(upper_element_bounds<int64_t>(
-                   Parameter{"", std::vector<int64_t>{1, 2, 3}}, 0)
-                   .success());
+      Parameter{"", std::vector<int64_t>{1, 2, 3}}, 0));
   EXPECT_TRUE(upper_element_bounds<int64_t>(
-                  Parameter{"", std::vector<int64_t>{1, 2, 3}}, 3)
-                  .success());
+      Parameter{"", std::vector<int64_t>{1, 2, 3}}, 3));
   EXPECT_TRUE(
-      upper_element_bounds<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0)
-          .success());
+      upper_element_bounds<int64_t>(Parameter{"", std::vector<int64_t>{}}, 0));
 
   EXPECT_FALSE(upper_element_bounds<bool>(
-                   Parameter{"", std::vector<bool>{true, false}}, false)
-                   .success());
+      Parameter{"", std::vector<bool>{true, false}}, false));
   EXPECT_TRUE(upper_element_bounds<bool>(
-                  Parameter{"", std::vector<bool>{true, false}}, true)
-                  .success());
+      Parameter{"", std::vector<bool>{true, false}}, true));
   EXPECT_FALSE(upper_element_bounds<bool>(
-                   Parameter{"", std::vector<bool>{true, false}}, false)
-                   .success());
+      Parameter{"", std::vector<bool>{true, false}}, false));
   EXPECT_TRUE(
-      upper_element_bounds<bool>(Parameter{"", std::vector<bool>{}}, true)
-          .success());
+      upper_element_bounds<bool>(Parameter{"", std::vector<bool>{}}, true));
 }
 
 }  // namespace parameter_traits


### PR DESCRIPTION
- Add tl_expected as dependency
- Validation result is now tl::expected

## Breaking changes

This PR replaces the custom `Result` type with a type based on `tl::expected`. This will mean that custom validator functions will require code changes to build with this change. See the changes to the example, MIGRATION.md notes, and/or PRs I'll prepare for ros2_controlls usage of custom validators.
