### PR TITLE
Use YAML loader which is compatible with PyYAML 3.12

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/main.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/main.py
@@ -987,7 +987,7 @@ class GenerateCode:
         yaml_file = sys.argv[2]
         with open(yaml_file) as f:
             try:
-                docs = yaml.load_all(f, Loader=yaml.FullLoader)
+                docs = yaml.load_all(f, Loader=yaml.Loader)
                 doc = list(docs)[0]
             except ParserError as e:
                 raise compile_error(str(e))


### PR DESCRIPTION
RHEL 8 packages PyYAML 3.12, which does not have the `FullLoader` referenced here. If the `SafeLoader` can't be used, the only other option available is the `Loader` (aka `UnsafeLoader`).

Fixes #85