### PR TITLE
Add missing dependency on PyYAML

### DIFF
--- a/generate_parameter_library_py/package.xml
+++ b/generate_parameter_library_py/package.xml
@@ -11,6 +11,7 @@
   <depend>python3</depend>
   <depend>python3-jinja2</depend>
   <depend>python3-typeguard</depend>
+  <depend>python3-yaml</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>python3-pytest</test_depend>


### PR DESCRIPTION
I'm sorry about the "onion peeling" here, but my local test environment wasn't sufficient to verify that dependencies were properly declared. It's very interesting that this missing dependency doesn't break the Ubuntu builds, but clearly it is indeed undeclared here.

Example failure:
https://build.ros2.org/job/Rbin_rhel_el864__generate_parameter_library_example__rhel_8_x86_64__binary/47

Referenced here:
https://github.com/PickNikRobotics/generate_parameter_library/blob/33caa0e83535db8cb7077e021b4d1b128bb41a24/generate_parameter_library_py/generate_parameter_library_py/main.py#L32

The rosdep key is here:
https://github.com/ros/rosdistro/blob/39f72ed2f2d83dba4cb1c71520dfd3c123b1ad0d/rosdep/python.yaml#L9746-L9759