### PR TITLE
Add keyword INTERFACE to fix build error 'ar: no archive members specified' on macOS

### DIFF
--- a/generate_parameter_library/cmake/generate_parameter_library.cmake
+++ b/generate_parameter_library/cmake/generate_parameter_library.cmake
@@ -74,13 +74,13 @@ function(generate_parameter_library LIB_NAME YAML_FILE)
   )
 
   # Create the library target
-  add_library(${LIB_NAME} ${PARAM_HEADER_FILE} ${VALIDATE_HEADER})
-  target_include_directories(${LIB_NAME} PUBLIC
+  add_library(${LIB_NAME} INTERFACE ${PARAM_HEADER_FILE} ${VALIDATE_HEADER})
+  target_include_directories(${LIB_NAME} INTERFACE
     $<BUILD_INTERFACE:${LIB_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include/>
   )
   set_target_properties(${LIB_NAME} PROPERTIES LINKER_LANGUAGE CXX)
-  target_link_libraries(${LIB_NAME}
+  target_link_libraries(${LIB_NAME} INTERFACE
     fmt::fmt
     parameter_traits::parameter_traits
     rclcpp::rclcpp


### PR DESCRIPTION
On macOS, CMake (3.23) could not build the generated target: It cannot produce the static library with the error
```
ar: no archive members specified
```
because there is no object file supplied (the generated target is header-only). Simply adding the keyword `INTERFACE` disables building the static library.