### PR TITLE
Mark deprecated rsl method and propose alternative in the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,16 +216,16 @@ Some of these validators work only on value types, some on string types, and oth
 The built-in validator functions provided by this package are:
 
 **Value validators**
-| Function               | Arguments           | Description                          |
-|------------------------|---------------------|--------------------------------------|
-| bounds<>               | [lower, upper]      | Bounds checking (inclusive)          |
-| lower_bounds<>         | [lower]             | Lower bounds (inclusive)             |
-| upper_bounds<>         | [upper]             | Upper bounds (inclusive)             |
-| lt<>                   | [value]             | parameter < value                    |
-| gt<>                   | [value]             | parameter > value                    |
-| lt_eq<>                | [value]             | parameter <= value (upper_bounds)    |
-| gt_eq<>                | [value]             | parameter >= value (lower_bounds)    |
-| one_of<>               | [[val1, val2, ...]] | Value is one of the specified values |
+| Function               | Arguments           | Description                           |
+|------------------------|---------------------|---------------------------------------|
+| bounds<>               | [lower, upper]      | Bounds checking (inclusive)           |
+| lower_bounds<>         | [lower]             | Lower bounds [Deprecated, use `gt_eq`]|
+| upper_bounds<>         | [upper]             | Upper bounds [Deprecated, use `lt_eq`]|
+| lt<>                   | [value]             | parameter < value                     |
+| gt<>                   | [value]             | parameter > value                     |
+| lt_eq<>                | [value]             | parameter <= value (upper_bounds)     |
+| gt_eq<>                | [value]             | parameter >= value (lower_bounds)     |
+| one_of<>               | [[val1, val2, ...]] | Value is one of the specified values  |
 
 **String validators**
 | Function               | Arguments           | Description                                     |

--- a/example/src/parameters.yaml
+++ b/example/src/parameters.yaml
@@ -37,7 +37,7 @@ admittance_controller:
         default_value: 1.0,
         description: "proportional gain term",
         validation: {
-          lower_bounds<>: [ 0 ],
+          gt_eq<>: [ 0 ],
         }
       }
       i: {

--- a/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
@@ -31,7 +31,7 @@ admittance_controller:
         default_value: 1.0,
         description: "proportional gain term",
         validation: {
-          lower_bounds<>: [ 0 ],
+          gt_eq<>: [ 0 ],
         }
       }
       i: {


### PR DESCRIPTION
For the reference: PickNikRobotics/RSL#78

Deprecation can be seen on the CI, e.g.:

https://github.com/ros-controls/ros2_controllers/actions/runs/4618180647/jobs/8165304008?pr=434#step:6:877

For an example of changes see ros-controls/ros2_controllers#561
