### PR TITLE
Populate Range Constraints in Parameter Descriptors from Validation Functions

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -37,10 +37,16 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+  # example_test_gtest
   add_rostest_with_parameters_gtest(test_example_gtest test/example_test_gtest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/example_params.yaml)
   target_include_directories(test_example_gtest PRIVATE include)
   target_link_libraries(test_example_gtest admittance_controller_parameters rclcpp::rclcpp)
+  # descriptor_test_gtest
+  add_rostest_with_parameters_gtest(test_descriptor_gtest test/descriptor_test_gtest.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/example_params.yaml)
+  target_include_directories(test_descriptor_gtest PRIVATE include)
+  target_link_libraries(test_descriptor_gtest admittance_controller_parameters rclcpp::rclcpp)
 
   find_package(ament_cmake_gmock REQUIRED)
   add_rostest_with_parameters_gmock(test_example_gmock test/example_test_gmock.cpp

--- a/example/src/parameters.yaml
+++ b/example/src/parameters.yaml
@@ -37,7 +37,7 @@ admittance_controller:
         default_value: 1.0,
         description: "proportional gain term",
         validation: {
-          lower_bounds<>: [ 0 ],
+          lower_bounds<>: [ 0.0001 ],
         }
       }
       i: {

--- a/example/src/parameters.yaml
+++ b/example/src/parameters.yaml
@@ -242,12 +242,21 @@ admittance_controller:
     default_value: false,
     description: "if enabled, the velocity commanded to the admittance controller is added to its calculated admittance velocity"
   }
-  less_than_eq_15: {
-      type: int,
-      default_value: 13,
-      validation: {
-        lt_eq: [15]
-      }
+  lt_eq_fifteen: {
+    type: int,
+    default_value: 1,
+    description: "should be a number less than or equal to 15",
+    validation: {
+      lt_eq<>: [ 15 ],
+    }
+  }
+  gt_fifteen: {
+    type: int,
+    default_value: 16,
+    description: "should be a number greater than 15",
+    validation: {
+      gt<>: [ 15 ],
+    }
   }
   one_number: {
     type: int,

--- a/example/src/parameters.yaml
+++ b/example/src/parameters.yaml
@@ -242,6 +242,13 @@ admittance_controller:
     default_value: false,
     description: "if enabled, the velocity commanded to the admittance controller is added to its calculated admittance velocity"
   }
+  less_than_eq_15: {
+      type: int,
+      default_value: 13,
+      validation: {
+        lt_eq: [15]
+      }
+  }
   one_number: {
     type: int,
     default_value: 14540,

--- a/example/test/descriptor_test_gtest.cpp
+++ b/example/test/descriptor_test_gtest.cpp
@@ -1,0 +1,76 @@
+// Copyright 2022 Stogl Robotics Consulting
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the PickNik Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Author: Denis Štogl
+//
+
+#include "admittance_controller_parameters.hpp"
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+
+#include <memory>
+
+class DescriptorTest : public ::testing::Test {
+ public:
+  void SetUp() {
+    example_test_node_ = std::make_shared<rclcpp::Node>("example_test_node");
+
+    std::shared_ptr<admittance_controller::ParamListener> param_listener =
+        std::make_shared<admittance_controller::ParamListener>(
+            example_test_node_->get_node_parameters_interface());
+    params_ = param_listener->get_params();
+    std::vector<std::string> names = {"admittance.damping_ratio", "one_number"};
+    descriptors_ = param_listener->get_descriptors(names);
+  }
+
+  void TearDown() { example_test_node_.reset(); }
+
+ protected:
+  std::shared_ptr<rclcpp::Node> example_test_node_;
+  admittance_controller::Params params_;
+  std::vector<rcl_interfaces::msg::ParameterDescriptor> descriptors_;
+};
+
+TEST_F(DescriptorTest, check_floating_point_descriptors) {
+  ASSERT_EQ(descriptors_[0].floating_point_range.at(0).from_value, 0.1);
+  ASSERT_EQ(descriptors_[0].floating_point_range.at(0).to_value, 10);
+}
+
+TEST_F(DescriptorTest, check_integer_descriptors) {
+  ASSERT_EQ(descriptors_[1].integer_range.at(0).from_value, 1024);
+  ASSERT_EQ(descriptors_[1].integer_range.at(0).to_value, 65535);
+}
+
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/example/test/descriptor_test_gtest.cpp
+++ b/example/test/descriptor_test_gtest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Stogl Robotics Consulting
+// Copyright 2023 Picknik Robotics
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -26,7 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// Author: Denis Štogl
+// Author: Chance Cardona
 //
 
 #include "admittance_controller_parameters.hpp"

--- a/example/test/descriptor_test_gtest.cpp
+++ b/example/test/descriptor_test_gtest.cpp
@@ -45,7 +45,7 @@ class DescriptorTest : public ::testing::Test {
         std::make_shared<admittance_controller::ParamListener>(
             example_test_node_->get_node_parameters_interface());
     params_ = param_listener->get_params();
-    std::vector<std::string> names = {"admittance.damping_ratio", "one_number", "pid.joint4.p", "less_than_eq_15"};
+    std::vector<std::string> names = {"admittance.damping_ratio", "one_number", "pid.joint4.p", "lt_eq_fifteen", "gt_fifteen"};
     descriptors_ = param_listener->get_descriptors(names);
   }
 
@@ -57,28 +57,31 @@ class DescriptorTest : public ::testing::Test {
   std::vector<rcl_interfaces::msg::ParameterDescriptor> descriptors_;
 };
 
-// Checks element_bounds<>
+// Checks element_bounds<> on a float
 TEST_F(DescriptorTest, check_floating_point_descriptors) {
   EXPECT_EQ(descriptors_[0].floating_point_range.at(0).from_value, 0.1);
   EXPECT_EQ(descriptors_[0].floating_point_range.at(0).to_value, 10);
 }
 
-// Checks bounds<>
+// Checks bounds<> on an int
 TEST_F(DescriptorTest, check_integer_descriptors) {
   EXPECT_EQ(descriptors_[1].integer_range.at(0).from_value, 1024);
   EXPECT_EQ(descriptors_[1].integer_range.at(0).to_value, 65535);
 }
 
-// Checks lower_bounds
 TEST_F(DescriptorTest, check_lower_upper_bounds) {
   EXPECT_EQ(descriptors_[2].floating_point_range.at(0).from_value, 0.0001);
   EXPECT_EQ(descriptors_[2].floating_point_range.at(0).to_value, std::numeric_limits<double>::max());
 }
 
-// Checks lt_eq
 TEST_F(DescriptorTest, check_lt_eq) {
-  EXPECT_EQ(descriptors_[3].floating_point_range.at(0).from_value, std::numeric_limits<double>::lowest());
-  EXPECT_EQ(descriptors_[3].floating_point_range.at(0).to_value, 15);
+  EXPECT_EQ(descriptors_[3].integer_range.at(0).from_value, std::numeric_limits<int>::lowest());
+  EXPECT_EQ(descriptors_[3].integer_range.at(0).to_value, 15);
+}
+
+TEST_F(DescriptorTest, check_gt) {
+  EXPECT_EQ(descriptors_[4].integer_range.at(0).from_value, 15);
+  EXPECT_EQ(descriptors_[4].integer_range.at(0).to_value, std::numeric_limits<int>::max());
 }
 
 

--- a/example/test/descriptor_test_gtest.cpp
+++ b/example/test/descriptor_test_gtest.cpp
@@ -32,6 +32,7 @@
 #include "admittance_controller_parameters.hpp"
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
+#include <limits.h>
 
 #include <memory>
 
@@ -44,7 +45,7 @@ class DescriptorTest : public ::testing::Test {
         std::make_shared<admittance_controller::ParamListener>(
             example_test_node_->get_node_parameters_interface());
     params_ = param_listener->get_params();
-    std::vector<std::string> names = {"admittance.damping_ratio", "one_number"};
+    std::vector<std::string> names = {"admittance.damping_ratio", "one_number", "pid.joint4.p", "less_than_eq_15"};
     descriptors_ = param_listener->get_descriptors(names);
   }
 
@@ -56,14 +57,28 @@ class DescriptorTest : public ::testing::Test {
   std::vector<rcl_interfaces::msg::ParameterDescriptor> descriptors_;
 };
 
+// Checks element_bounds<>
 TEST_F(DescriptorTest, check_floating_point_descriptors) {
-  ASSERT_EQ(descriptors_[0].floating_point_range.at(0).from_value, 0.1);
-  ASSERT_EQ(descriptors_[0].floating_point_range.at(0).to_value, 10);
+  EXPECT_EQ(descriptors_[0].floating_point_range.at(0).from_value, 0.1);
+  EXPECT_EQ(descriptors_[0].floating_point_range.at(0).to_value, 10);
 }
 
+// Checks bounds<>
 TEST_F(DescriptorTest, check_integer_descriptors) {
-  ASSERT_EQ(descriptors_[1].integer_range.at(0).from_value, 1024);
-  ASSERT_EQ(descriptors_[1].integer_range.at(0).to_value, 65535);
+  EXPECT_EQ(descriptors_[1].integer_range.at(0).from_value, 1024);
+  EXPECT_EQ(descriptors_[1].integer_range.at(0).to_value, 65535);
+}
+
+// Checks lower_bounds
+TEST_F(DescriptorTest, check_lower_upper_bounds) {
+  EXPECT_EQ(descriptors_[2].floating_point_range.at(0).from_value, 0.0001);
+  EXPECT_EQ(descriptors_[2].floating_point_range.at(0).to_value, std::numeric_limits<double>::max());
+}
+
+// Checks lt_eq
+TEST_F(DescriptorTest, check_lt_eq) {
+  EXPECT_EQ(descriptors_[3].floating_point_range.at(0).from_value, std::numeric_limits<double>::lowest());
+  EXPECT_EQ(descriptors_[3].floating_point_range.at(0).to_value, 15);
 }
 
 

--- a/example/test/descriptor_test_gtest.cpp
+++ b/example/test/descriptor_test_gtest.cpp
@@ -48,7 +48,7 @@ class DescriptorTest : public ::testing::Test {
     std::vector<std::string> names = {"admittance.damping_ratio", "one_number",
                                       "pid.joint4.p", "lt_eq_fifteen",
                                       "gt_fifteen"};
-    descriptors_ = param_listener->get_descriptors(names);
+    descriptors_ = example_test_node_->describe_parameters(names);
   }
 
   void TearDown() { example_test_node_.reset(); }

--- a/example/test/descriptor_test_gtest.cpp
+++ b/example/test/descriptor_test_gtest.cpp
@@ -32,8 +32,8 @@
 #include "admittance_controller_parameters.hpp"
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
-#include <limits.h>
 
+#include <limits>
 #include <memory>
 
 class DescriptorTest : public ::testing::Test {
@@ -45,7 +45,9 @@ class DescriptorTest : public ::testing::Test {
         std::make_shared<admittance_controller::ParamListener>(
             example_test_node_->get_node_parameters_interface());
     params_ = param_listener->get_params();
-    std::vector<std::string> names = {"admittance.damping_ratio", "one_number", "pid.joint4.p", "lt_eq_fifteen", "gt_fifteen"};
+    std::vector<std::string> names = {"admittance.damping_ratio", "one_number",
+                                      "pid.joint4.p", "lt_eq_fifteen",
+                                      "gt_fifteen"};
     descriptors_ = param_listener->get_descriptors(names);
   }
 
@@ -71,19 +73,21 @@ TEST_F(DescriptorTest, check_integer_descriptors) {
 
 TEST_F(DescriptorTest, check_lower_upper_bounds) {
   EXPECT_EQ(descriptors_[2].floating_point_range.at(0).from_value, 0.0001);
-  EXPECT_EQ(descriptors_[2].floating_point_range.at(0).to_value, std::numeric_limits<double>::max());
+  EXPECT_EQ(descriptors_[2].floating_point_range.at(0).to_value,
+            std::numeric_limits<double>::max());
 }
 
 TEST_F(DescriptorTest, check_lt_eq) {
-  EXPECT_EQ(descriptors_[3].integer_range.at(0).from_value, std::numeric_limits<int>::lowest());
+  EXPECT_EQ(descriptors_[3].integer_range.at(0).from_value,
+            std::numeric_limits<int>::lowest());
   EXPECT_EQ(descriptors_[3].integer_range.at(0).to_value, 15);
 }
 
 TEST_F(DescriptorTest, check_gt) {
   EXPECT_EQ(descriptors_[4].integer_range.at(0).from_value, 15);
-  EXPECT_EQ(descriptors_[4].integer_range.at(0).to_value, std::numeric_limits<int>::max());
+  EXPECT_EQ(descriptors_[4].integer_range.at(0).to_value,
+            std::numeric_limits<int>::max());
 }
-
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/example/test/example_test_gtest.cpp
+++ b/example/test/example_test_gtest.cpp
@@ -64,6 +64,11 @@ TEST_F(ExampleTest, check_parameters) {
   ASSERT_EQ(params_.ft_sensor.filter_coefficient, 0.1);
 }
 
+//TEST_F(ExampleTest, check_descriptors) {
+//  ASSERT_EQ(params_.admittance.damping_ratio.descriptor.integer_range[0], 0.1);
+//  //ASSERT_EQ(descriptors_.admittance.damping_ratio.integer_range[0], 0.1);
+//}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);

--- a/example/test/example_test_gtest.cpp
+++ b/example/test/example_test_gtest.cpp
@@ -64,11 +64,6 @@ TEST_F(ExampleTest, check_parameters) {
   ASSERT_EQ(params_.ft_sensor.filter_coefficient, 0.1);
 }
 
-//TEST_F(ExampleTest, check_descriptors) {
-//  ASSERT_EQ(params_.admittance.damping_ratio.descriptor.integer_range[0], 0.1);
-//  //ASSERT_EQ(descriptors_.admittance.damping_ratio.integer_range[0], 0.1);
-//}
-
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -3,18 +3,17 @@ if (!parameters_interface_->has_parameter(prefix_ + "{{parameter_name}}")) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
-{# TODO: Include lt, gt, lt_eq, and gt_eq rsl validators along with upper and lower bounds. #}
-{%- for validation in parameter_validations if "bounds" in validation.function_name%}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if "DOUBLE" in parameter_type %}
 {%- if validation.arguments|length == 2 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
+{%- elif ("lower" in validation.function_name or "gt" in validation.function_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
-{%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
+{%- elif ("upper" in validation.function_name or "lt" in validation.function_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
@@ -24,11 +23,11 @@ descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.argu
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
+{%- elif ("lower" in validation.function_name or "gt" in validation.function_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int>::max();
-{%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
+{%- elif ("upper" in validation.function_name or "lt" in validation.function_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int>::lowest();
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -3,7 +3,8 @@ if (!parameters_interface_->has_parameter(prefix_ + "{{parameter_name}}")) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
-{%- for validation in parameter_validations if "bounds" in validation.function_name or "t_eq" in validation.function_name %}
+{# TODO: Include lt, gt, lt_eq, and gt_eq rsl validators along with upper and lower bounds. #}
+{%- for validation in parameter_validations if "bounds" in validation.function_name%}
 {%- if "DOUBLE" in parameter_type %}
 {%- if validation.arguments|length == 2 %}
 descriptor.floating_point_range.resize({{loop.index}});
@@ -12,8 +13,10 @@ descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.argu
 {%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
 {%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
 descriptor.floating_point_range.resize({{loop.index}});
+descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
 {%- endif %}
 {%- elif "INTEGER" in parameter_type %}
@@ -24,8 +27,10 @@ descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1
 {%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int>::max();
 {%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
 descriptor.integer_range.resize({{loop.index}});
+descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int>::lowest();
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
 {%- endif %}
 {%- endif %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -4,13 +4,13 @@ rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
 {%- for validation in parameter_validations %}
-{%- if validation.function_name == "element_bounds" %}
+{%- if validation.function_name.startswith("element_bounds") %}
 {%- if parameter_type == "DOUBLE_ARRAY" %}
-descriptor.floating_point_range.from_value = {{parameter_validations[0].arguments[0]}};
-descriptor.floating_point_range.to_value = {{parameter_validations[0].arguments[1]}};
-{%- elif parameter_type =="INTEGER_ARRAY" %}
-descriptor.integer_range.from_value = {{parameter_validations[0].arguments[0]}};
-descriptor.integer_range.to_value = {{parameter_validations[0].arguments[1]}};
+descriptor.floating_point_range.at(0).from_value = {{validation.arguments[0]}};
+descriptor.floating_point_range.at(0).to_value = {{validation.arguments[1]}};
+{%- elif parameter_type == "INTEGER_ARRAY" %}
+descriptor.integer_range.at(0).from_value = {{validation.arguments[0]}};
+descriptor.integer_range.at(0).to_value = {{validation.arguments[1]}};
 {%- endif %}
 {%- endif %}
 {%- endfor %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -3,15 +3,31 @@ if (!parameters_interface_->has_parameter(prefix_ + "{{parameter_name}}")) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
-{%- for validation in parameter_validations if validation.function_name.startswith("element_bounds") %}
-{%- if parameter_type == "DOUBLE_ARRAY" %}
+{%- for validation in parameter_validations if "bounds" in validation.function_name or "t_eq" in validation.function_name %}
+{%- if "DOUBLE" in parameter_type %}
+{%- if validation.arguments|length == 2 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif parameter_type == "INTEGER_ARRAY" %}
+{%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
+descriptor.floating_point_range.resize({{loop.index}});
+descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+{%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
+descriptor.floating_point_range.resize({{loop.index}});
+descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
+{%- endif %}
+{%- elif "INTEGER" in parameter_type %}
+{%- if validation.arguments|length == 2 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
+{%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
+descriptor.integer_range.resize({{loop.index}});
+descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+{%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
+descriptor.integer_range.resize({{loop.index}});
+descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
+{%- endif %}
 {%- endif %}
 {%- endfor %}
 {%- if not parameter_value|length %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -3,15 +3,17 @@ if (!parameters_interface_->has_parameter(prefix_ + "{{parameter_name}}")) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
-{% if parameter_validations|length -%}
-{% if parameter_type == "DOUBLE_ARRAY" %}
+{%- for validation in parameter_validations %}
+{%- if validation.function_name == "element_bounds" %}
+{%- if parameter_type == "DOUBLE_ARRAY" %}
 descriptor.floating_point_range.from_value = {{parameter_validations[0].arguments[0]}};
 descriptor.floating_point_range.to_value = {{parameter_validations[0].arguments[1]}};
-{% elif parameter_type =="INTEGER_ARRAY" %}
+{%- elif parameter_type =="INTEGER_ARRAY" %}
 descriptor.integer_range.from_value = {{parameter_validations[0].arguments[0]}};
 descriptor.integer_range.to_value = {{parameter_validations[0].arguments[1]}};
-{% endif %}
-{% endif -%}
+{%- endif %}
+{%- endif %}
+{%- endfor %}
 {%- if not parameter_value|length %}
 auto parameter = rclcpp::ParameterType::PARAMETER_{{parameter_type}};
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -3,15 +3,15 @@ if (!parameters_interface_->has_parameter(prefix_ + "{{parameter_name}}")) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
-{%- for validation in parameter_validations %}
-{%- if validation.function_name.startswith("element_bounds") %}
+{%- for validation in parameter_validations if validation.function_name.startswith("element_bounds") %}
 {%- if parameter_type == "DOUBLE_ARRAY" %}
-descriptor.floating_point_range.at(0).from_value = {{validation.arguments[0]}};
-descriptor.floating_point_range.at(0).to_value = {{validation.arguments[1]}};
+descriptor.floating_point_range.resize({{loop.index}});
+descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
 {%- elif parameter_type == "INTEGER_ARRAY" %}
-descriptor.integer_range.at(0).from_value = {{validation.arguments[0]}};
-descriptor.integer_range.at(0).to_value = {{validation.arguments[1]}};
-{%- endif %}
+descriptor.integer_range.resize({{loop.index}});
+descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
 {%- endif %}
 {%- endfor %}
 {%- if not parameter_value|length %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -3,6 +3,15 @@ if (!parameters_interface_->has_parameter(prefix_ + "{{parameter_name}}")) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
+{% if parameter_validations|length -%}
+{% if parameter_type == "DOUBLE_ARRAY" %}
+descriptor.floating_point_range.from_value = {{parameter_validations[0].arguments[0]}};
+descriptor.floating_point_range.to_value = {{parameter_validations[0].arguments[1]}};
+{% elif parameter_type =="INTEGER_ARRAY" %}
+descriptor.integer_range.from_value = {{parameter_validations[0].arguments[0]}};
+descriptor.integer_range.to_value = {{parameter_validations[0].arguments[1]}};
+{% endif %}
+{% endif -%}
 {%- if not parameter_value|length %}
 auto parameter = rclcpp::ParameterType::PARAMETER_{{parameter_type}};
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
@@ -7,15 +7,15 @@ if (!parameters_interface_->has_parameter(param_name)) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
-{%- for validation in parameter_validations %}
-{%- if validation.function_name.startswith("element_bounds") %}
+{%- for validation in parameter_validations if validation.function_name.startswith("element_bounds") %}
 {%- if parameter_type == "DOUBLE_ARRAY" %}
-descriptor.floating_point_range.at(0).from_value = {{validation.arguments[0]}};
-descriptor.floating_point_range.at(0).to_value = {{validations.arguments[1]}};
+descriptor.floating_point_range.resize({{loop.index}});
+descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validations.arguments[1]}};
 {%- elif parameter_type =="INTEGER_ARRAY" %}
-descriptor.integer_range.at(0).from_value = {{validations.arguments[0]}};
-descriptor.integer_range.at(0).to_value = {{validation.arguments[1]}};
-{%- endif %}
+descriptor.integer_range.resize({{loop.index}});
+descriptor.integer_range.at({{loop.index0}}).from_value = {{validations.arguments[0]}};
+descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
 {%- endif %}
 {%- endfor %}
 {%- if not default_value|length %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
@@ -7,18 +7,17 @@ if (!parameters_interface_->has_parameter(param_name)) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
-{# TODO: Include lt, gt, lt_eq, and gt_eq rsl validators along with upper and lower bounds. #}
-{%- for validation in parameter_validations if "bounds" in validation.function_name%}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if "DOUBLE" in parameter_type %}
 {%- if validation.arguments|length == 2 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
+{%- elif ("lower" in validation.function_name or "gt" in validation.function_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
-{%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
+{%- elif ("upper" in validation.function_name or "lt" in validation.function_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
@@ -28,11 +27,11 @@ descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.argu
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
+{%- elif ("lower" in validation.function_name or "gt" in validation.function_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int>::max();
-{%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
+{%- elif ("upper" in validation.function_name or "lt" in validation.function_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int>::lowest();
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
@@ -7,7 +7,8 @@ if (!parameters_interface_->has_parameter(param_name)) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
-{%- for validation in parameter_validations if "bounds" in validation.function_name or "t_eq" in validation.function_name %}
+{# TODO: Include lt, gt, lt_eq, and gt_eq rsl validators along with upper and lower bounds. #}
+{%- for validation in parameter_validations if "bounds" in validation.function_name%}
 {%- if "DOUBLE" in parameter_type %}
 {%- if validation.arguments|length == 2 %}
 descriptor.floating_point_range.resize({{loop.index}});
@@ -16,8 +17,10 @@ descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.argu
 {%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
 {%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
 descriptor.floating_point_range.resize({{loop.index}});
+descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
 {%- endif %}
 {%- elif "INTEGER" in parameter_type %}
@@ -28,8 +31,10 @@ descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1
 {%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int>::max();
 {%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
 descriptor.integer_range.resize({{loop.index}});
+descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int>::lowest();
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
 {%- endif %}
 {%- endif %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
@@ -7,6 +7,17 @@ if (!parameters_interface_->has_parameter(param_name)) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
+{%- for validation in parameter_validations %}
+{%- if validation.function_name.startswith("element_bounds") %}
+{%- if parameter_type == "DOUBLE_ARRAY" %}
+descriptor.floating_point_range.at(0).from_value = {{validation.arguments[0]}};
+descriptor.floating_point_range.at(0).to_value = {{validations.arguments[1]}};
+{%- elif parameter_type =="INTEGER_ARRAY" %}
+descriptor.integer_range.at(0).from_value = {{validations.arguments[0]}};
+descriptor.integer_range.at(0).to_value = {{validation.arguments[1]}};
+{%- endif %}
+{%- endif %}
+{%- endfor %}
 {%- if not default_value|length %}
 auto parameter = rclcpp::ParameterType::PARAMETER_{{parameter_type}};
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
@@ -7,15 +7,31 @@ if (!parameters_interface_->has_parameter(param_name)) {
 rcl_interfaces::msg::ParameterDescriptor descriptor;
 descriptor.description = "{{parameter_description}}";
 descriptor.read_only = {{parameter_read_only}};
-{%- for validation in parameter_validations if validation.function_name.startswith("element_bounds") %}
-{%- if parameter_type == "DOUBLE_ARRAY" %}
+{%- for validation in parameter_validations if "bounds" in validation.function_name or "t_eq" in validation.function_name %}
+{%- if "DOUBLE" in parameter_type %}
+{%- if validation.arguments|length == 2 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validations.arguments[1]}};
-{%- elif parameter_type =="INTEGER_ARRAY" %}
+descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
+{%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
+descriptor.floating_point_range.resize({{loop.index}});
+descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+{%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
+descriptor.floating_point_range.resize({{loop.index}});
+descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
+{%- endif %}
+{%- elif "INTEGER" in parameter_type %}
+{%- if validation.arguments|length == 2 %}
 descriptor.integer_range.resize({{loop.index}});
-descriptor.integer_range.at({{loop.index0}}).from_value = {{validations.arguments[0]}};
+descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
+{%- elif "lower" in validation.function_name or "gt_eq" in validation.function_name %}
+descriptor.integer_range.resize({{loop.index}});
+descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
+{%- elif "upper" in validation.function_name or "lt_eq" in validation.function_name %}
+descriptor.integer_range.resize({{loop.index}});
+descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
+{%- endif %}
 {%- endif %}
 {%- endfor %}
 {%- if not default_value|length %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <functional>
+#include <limits>
 #include <mutex>
 #include <rclcpp/node.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
@@ -113,6 +113,11 @@ struct StackParams {
       return params_;
     }
 
+    std::vector<rcl_interfaces::msg::ParameterDescriptor> get_descriptors(const std::vector<std::string> & names) const{
+      std::lock_guard<std::mutex> lock(mutex_);
+      return parameters_interface_->describe_parameters(names);
+    }
+
     bool is_old(Params const& other) const {
       std::lock_guard<std::mutex> lock(mutex_);
       return params_.__stamp != other.__stamp;

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
@@ -114,11 +114,6 @@ struct StackParams {
       return params_;
     }
 
-    std::vector<rcl_interfaces::msg::ParameterDescriptor> get_descriptors(const std::vector<std::string> & names) const{
-      std::lock_guard<std::mutex> lock(mutex_);
-      return parameters_interface_->describe_parameters(names);
-    }
-
     bool is_old(Params const& other) const {
       std::lock_guard<std::mutex> lock(mutex_);
       return params_.__stamp != other.__stamp;

--- a/generate_parameter_library_py/generate_parameter_library_py/main.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/main.py
@@ -655,7 +655,6 @@ class DeclareParameter(DeclareParameterBase):
         else:
             self.parameter_value = self.parameter_name
 
-        #parameter_validations_str = "".join(str(x) for x in self.parameter_validations)
         parameter_validations = self.parameter_validations
         data = {
             "parameter_name": self.parameter_name,
@@ -692,7 +691,6 @@ class DeclareRuntimeParameter(DeclareParameterBase):
                 "add_set_runtime_parameter was not called before str()"
             )
 
-        # parameter_validations_str = "".join(str(x) for x in self.parameter_validations)
         if self.code_gen_variable.default_value is None:
             default_value = ""
         else:
@@ -702,7 +700,6 @@ class DeclareRuntimeParameter(DeclareParameterBase):
         mapped_param = get_dynamic_mapped_parameter(self.parameter_name)
         parameter_map = get_dynamic_parameter_map(self.parameter_name)
         struct_name = get_dynamic_struct_name(self.parameter_name)
-        #parameter_validations_str = "".join(str(x) for x in self.parameter_validations)
 
         data = {
             "struct_name": struct_name,

--- a/generate_parameter_library_py/generate_parameter_library_py/main.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/main.py
@@ -676,8 +676,9 @@ class DeclareRuntimeParameter(DeclareParameterBase):
         code_gen_variable: CodeGenVariableBase,
         parameter_description: str,
         parameter_read_only: bool,
+        parameter_validations: list
     ):
-        super().__init__(code_gen_variable, parameter_description, parameter_read_only)
+        super().__init__(code_gen_variable, parameter_description, parameter_read_only, parameter_validations)
         self.set_runtime_parameter = None
         self.param_struct_instance = "updated_params"
 
@@ -701,7 +702,7 @@ class DeclareRuntimeParameter(DeclareParameterBase):
         mapped_param = get_dynamic_mapped_parameter(self.parameter_name)
         parameter_map = get_dynamic_parameter_map(self.parameter_name)
         struct_name = get_dynamic_struct_name(self.parameter_name)
-        parameter_validations_str = "".join(str(x) for x in self.parameter_validations)
+        #parameter_validations_str = "".join(str(x) for x in self.parameter_validations)
 
         data = {
             "struct_name": struct_name,
@@ -716,7 +717,7 @@ class DeclareRuntimeParameter(DeclareParameterBase):
             "param_struct_instance": self.param_struct_instance,
             "parameter_field": parameter_field,
             "default_value": default_value,
-            "parameter_validations": str(parameter_validations_str)
+            "parameter_validations": self.parameter_validations
         }
 
         j2_template = Template(GenerateCode.templates["declare_runtime_parameter"])
@@ -868,7 +869,7 @@ class GenerateCode:
                 param_name, parameter_conversion
             )
             declare_parameter = DeclareRuntimeParameter(
-                code_gen_variable, description, read_only,
+                code_gen_variable, description, read_only, validations
             )
             declare_parameter.add_set_runtime_parameter(declare_parameter_set)
             update_parameter = UpdateRuntimeParameter(param_name, parameter_conversion)

--- a/generate_parameter_library_py/generate_parameter_library_py/main.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/main.py
@@ -849,7 +849,6 @@ class GenerateCode:
         ) = preprocess_inputs(name, value, nested_name_list)
 
         param_name = code_gen_variable.param_name
-        param_type = code_gen_variable.defined_type
         update_parameter_invalid = update_parameter_fail_validation()
         update_parameter_valid = update_parameter_pass_validation()
         parameter_conversion = code_gen_variable.parameter_as_function_str()

--- a/generate_parameter_library_py/generate_parameter_library_py/main.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/main.py
@@ -639,7 +639,7 @@ class DeclareParameterBase:
         code_gen_variable: CodeGenVariableBase,
         parameter_description: str,
         parameter_read_only: bool,
-        parameter_validations: list
+        parameter_validations: list,
     ):
         self.parameter_name = code_gen_variable.param_name
         self.parameter_description = parameter_description
@@ -662,7 +662,7 @@ class DeclareParameter(DeclareParameterBase):
             "parameter_type": self.code_gen_variable.get_parameter_type(),
             "parameter_description": self.parameter_description,
             "parameter_read_only": bool_to_str(self.parameter_read_only),
-            "parameter_validations": parameter_validations
+            "parameter_validations": parameter_validations,
         }
         j2_template = Template(GenerateCode.templates["declare_parameter"])
         code = j2_template.render(data, trim_blocks=True)
@@ -675,9 +675,14 @@ class DeclareRuntimeParameter(DeclareParameterBase):
         code_gen_variable: CodeGenVariableBase,
         parameter_description: str,
         parameter_read_only: bool,
-        parameter_validations: list
+        parameter_validations: list,
     ):
-        super().__init__(code_gen_variable, parameter_description, parameter_read_only, parameter_validations)
+        super().__init__(
+            code_gen_variable,
+            parameter_description,
+            parameter_read_only,
+            parameter_validations,
+        )
         self.set_runtime_parameter = None
         self.param_struct_instance = "updated_params"
 
@@ -714,7 +719,7 @@ class DeclareRuntimeParameter(DeclareParameterBase):
             "param_struct_instance": self.param_struct_instance,
             "parameter_field": parameter_field,
             "default_value": default_value,
-            "parameter_validations": self.parameter_validations
+            "parameter_validations": self.parameter_validations,
         }
 
         j2_template = Template(GenerateCode.templates["declare_runtime_parameter"])

--- a/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
@@ -46,7 +46,7 @@ admittance_controller:
     default_value: 1.0,
     description: "proportional gain term updated",
     validation: {
-      gt_eq: [ 0 ],
+      gt_eq: [ 0.0001 ],
     }
   }
 
@@ -56,6 +56,22 @@ admittance_controller:
     description: "should be a number less than 10",
     validation: {
       upper_bounds<>: [ 10 ],
+    }
+  }
+  lt_eq_fifteen: {
+    type: int,
+    default_value: 1,
+    description: "should be a number less than or equal to 15",
+    validation: {
+      lt_eq<>: [ 15 ],
+    }
+  }
+  gt_fifteen: {
+    type: int,
+    default_value: 16,
+    description: "should be a number greater than 15",
+    validation: {
+      gt<>: [ 15 ],
     }
   }
 

--- a/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
@@ -1,0 +1,58 @@
+admittance_controller:
+  #    # Having ".0" at the end is MUST, otherwise there is a loading error
+  #    # F = M*a + D*v + S*(x - x_d)
+  #    mass: {
+  #      type: double_array,
+  #      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation",
+  #      validation: {
+  #        fixed_size<>: 6,
+  #        element_bounds<>: [ 0.0001, 1000000.0 ]
+  #      }
+  #    }
+  #
+  #    damping_ratio: {
+  #      type: double_array,
+  #      description: "specifies damping ratio values for x, y, z, rx, ry, and rz used in the admittance calculation.
+  #      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))",
+  #      validation: {
+  #        fixed_size<>: 6,
+  #        validate_double_array_custom_func: [ 20.3, 5.0 ],
+  #        element_bounds<>: [ 0.1, 10.0 ]
+  #      }
+  #    }
+
+  stiffness: {
+    type: double_array,
+    description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation",
+    validation: {
+      element_bounds: [ 0.0001, 100000.0 ]
+    }
+  }
+  dankness: {
+    type: int_array,
+    description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation",
+    validation: {
+      element_bounds: [ 1, 100 ]
+    }
+  }
+
+  mass: {
+    type: double_array,
+    description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation",
+    validation: {
+      fixed_size<>: 6,
+      element_bounds<>: [ 0.0001, 1000000.0 ]
+    }
+  }
+
+  # general settings
+  enable_parameter_update_without_reactivation: {
+    type: bool,
+    default_value: true,
+    description: "if enabled, read_only parameters will be dynamically updated in the control loop"
+  }
+  use_feedforward_commanded_input: {
+    type: bool,
+    default_value: false,
+    description: "if enabled, the velocity commanded to the admittance controller is added to its calculated admittance velocity"
+  }

--- a/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
@@ -1,26 +1,4 @@
 admittance_controller:
-  #    # Having ".0" at the end is MUST, otherwise there is a loading error
-  #    # F = M*a + D*v + S*(x - x_d)
-  #    mass: {
-  #      type: double_array,
-  #      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation",
-  #      validation: {
-  #        fixed_size<>: 6,
-  #        element_bounds<>: [ 0.0001, 1000000.0 ]
-  #      }
-  #    }
-  #
-  #    damping_ratio: {
-  #      type: double_array,
-  #      description: "specifies damping ratio values for x, y, z, rx, ry, and rz used in the admittance calculation.
-  #      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))",
-  #      validation: {
-  #        fixed_size<>: 6,
-  #        validate_double_array_custom_func: [ 20.3, 5.0 ],
-  #        element_bounds<>: [ 0.1, 10.0 ]
-  #      }
-  #    }
-
   stiffness: {
     type: double_array,
     description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation",
@@ -45,7 +23,43 @@ admittance_controller:
     }
   }
 
-  # general settings
+  one_number: {
+    type: int,
+    default_value: 14540,
+    read_only: true,
+    validation: {
+      bounds<>: [ 1024, 65535 ]
+    }
+  }
+
+  p: {
+    type: double,
+    default_value: 1.0,
+    description: "proportional gain term",
+    validation: {
+      lower_bounds<>: [ 0 ],
+    }
+  }
+  
+  p2: {
+    type: double,
+    default_value: 1.0,
+    description: "proportional gain term updated",
+    validation: {
+      gt_eq: [ 0 ],
+    }
+  }
+
+  under_ten: {
+    type: double,
+    default_value: 1.0,
+    description: "should be a number less than 10",
+    validation: {
+      upper_bounds<>: [ 10 ],
+    }
+  }
+
+    # general settings
   enable_parameter_update_without_reactivation: {
     type: bool,
     default_value: true,

--- a/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
@@ -40,7 +40,7 @@ admittance_controller:
       lower_bounds<>: [ 0 ],
     }
   }
-  
+
   p2: {
     type: double,
     default_value: 1.0,


### PR DESCRIPTION
This PR resolves [Issue 96](https://github.com/PickNikRobotics/generate_parameter_library/issues/96). 

This uses the `declare_parameter` and `declare_runtime_parameter` templates to populate the parameter descriptor. 
For this, some string checking on the validation function was added to see if it was appropriate to populate the Descriptor range constraints.  In the jinja templates I simply check against the string name of the validation function and the number of arguments. This should work in all cases here, but strange things may happen if another validation function with a substring of "gt" or "lt" with 1 argument, or "bounds" with 2 args is either created in RSL or in a user defined validation function. For this purpose I figure this is acceptable. 

This also may not allow setting of the descriptors dynamically (only in the declaration) but that can be a future work (unless it's a simple change) if it's a desired feature.

This should work for the RSL validation functions: `bounds`, `element_bounds`, `lower_bounds`, `upper_bounds`, `gt_eq`, `lt_eq`, `gt`, and `lt` validation functions by using std::numerical_limits library to populate the corresponding `to_value` or `from_value` that's not defined with either `max()` or `lowest()` for that parameter cpp type.

To assist in Unit Tests, a `get_descriptors` method was also added in the `parameter_library_header` template.
Finally, a Unit Test was created in the `example` directory and should run when `colcon test` is run.  