### PR TITLE
Fix Parameter Descriptor Incorrectly Populating Range Constraints for size_lt and size_gt

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -9,11 +9,11 @@ descriptor.read_only = {{parameter_read_only}};
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif ("lower" in validation.function_name or "gt" in validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_name or "gt_eq" == validation.function_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
-{%- elif ("upper" in validation.function_name or "lt" in validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_name or "gt_eq" == validation.function_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_parameter
@@ -9,11 +9,11 @@ descriptor.read_only = {{parameter_read_only}};
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif ("lower" in validation.function_name or "gt" == validation.function_name or "gt_eq" == validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
-{%- elif ("upper" in validation.function_name or "lt" == validation.function_name or "gt_eq" == validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
@@ -23,11 +23,11 @@ descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.argu
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif ("lower" in validation.function_name or "gt" in validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int>::max();
-{%- elif ("upper" in validation.function_name or "lt" in validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int>::lowest();
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
@@ -13,11 +13,11 @@ descriptor.read_only = {{parameter_read_only}};
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif ("lower" in validation.function_name or "gt" == validation.function_name or "gt_eq" == validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
-{%- elif ("upper" in validation.function_name or "lt" == validation.function_name or "gt_eq" == validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
@@ -27,11 +27,11 @@ descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.argu
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif ("lower" in validation.function_name or "gt" in validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int>::max();
-{%- elif ("upper" in validation.function_name or "lt" in validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int>::lowest();
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/declare_runtime_parameter
@@ -13,11 +13,11 @@ descriptor.read_only = {{parameter_read_only}};
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif ("lower" in validation.function_name or "gt" in validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_name or "gt_eq" == validation.function_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
-{%- elif ("upper" in validation.function_name or "lt" in validation.function_name) and validation.arguments|length == 1 %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_name or "gt_eq" == validation.function_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};

--- a/generate_parameter_library_py/generate_parameter_library_py/main.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/main.py
@@ -484,10 +484,11 @@ class ValidationFunction:
     ):
         self.code_gen_variable = code_gen_variable
         self.function_name = function_name
+        self.function_base_name = function_name
         if function_name[-2:] == "<>":
-            self.function_name = function_name[:-2]
+            self.function_base_name = function_name[:-2]
             template_type = code_gen_variable.cpp_base_type
-            self.function_name += f"<{template_type}>"
+            self.function_name = self.function_base_name + f"<{template_type}>"
 
         if arguments is not None:
             self.arguments = arguments

--- a/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
@@ -74,6 +74,12 @@ admittance_controller:
       gt<>: [ 15 ],
     }
   }
+  # This shouldn't populate any description range constraints
+  fixed_array: {
+    type: double_array_fixed_10,
+    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3],
+    description: "test code generation for fixed sized array",
+  }
 
     # general settings
   enable_parameter_update_without_reactivation: {


### PR DESCRIPTION
Due to the string checking in the declare(_runtime)_parameters templates, `size_lt` and `size_gt` would incorrectly populate the descriptor range constraints since it also has 1 argument. This changes that line in the template to explicitly check for `lt`, `lt_eq`, `gt`, and `gt_eq` so that we avoid this error and hopefully other errors in the future. 

Not the cleanest implementation, but added a function_base_name without the template brackets `<>`. This passes the checks I've looked for and should reduce the descriptors being inadvertently filled unless the validation function name has both the substring `lesser`/`greater` and `bounds` in it with 1 argument. Could clean up in future if desired but would need to think about how to structure this in the jinja templates / main.py, as it's a bit long. But this should work without any false positives now.