### PR TITLE
Log when a parameter is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,3 +421,20 @@ class ParamListener {
 } // namespace cpp_namespace
 ```
 The structure of the `Params` struct and the logic for declaring and updating parameters is generated from a YAML file specification.
+
+# FAQ
+
+Q. What happens if I declare a parameter twice? Will I get an error at runtime?
+A. The declare routine that is generated checks to see if each parameter has been declared first before declaring it. Because of this you can declare a parameter twice but it will only have the properties of the first time you declared it. Here is some example generated code.
+```cpp
+if (!parameters_interface_->has_parameter(prefix_ + "scientific_notation_num")) {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description = "Test scientific notation";
+    descriptor.read_only = false;
+    auto parameter = to_parameter_value(updated_params.scientific_notation_num);
+    parameters_interface_->declare_parameter(prefix_ + "scientific_notation_num", parameter, descriptor);
+}
+```
+
+Q: How do I log when parameters change?
+A. The generated library outputs debug logs whenever a parameter is read from ROS.

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/parameter_library_header
@@ -102,6 +102,10 @@ struct StackParams {
         prefix_ += ".";
       }
 
+      if (!prefix.empty()) {
+        logger_ = rclcpp::get_logger("{{namespace}}." + prefix);
+      }
+
       parameters_interface_ = parameters_interface;
       declare_params();
       auto update_param_cb = [this](const std::vector<rclcpp::Parameter> &parameters){return this->update(parameters);};
@@ -198,6 +202,7 @@ struct StackParams {
       rclcpp::Clock clock_;
       std::shared_ptr<rclcpp::node_interfaces::OnSetParametersCallbackHandle> handle_;
       std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface_;
+      rclcpp::Logger logger_ = rclcpp::get_logger("{{namespace}}");
       std::mutex mutable mutex_;
   };
 

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/set_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/set_parameter
@@ -1,4 +1,5 @@
 param = parameters_interface_->get_parameter(prefix_ + "{{parameter_name}}");
+RCLCPP_DEBUG_STREAM(logger_, param.get_name() << ": " << param.get_type_name() << " = " << param.value_to_string());
 {% if parameter_validations|length -%}
 {{parameter_validations-}}
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/set_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/set_runtime_parameter
@@ -1,4 +1,5 @@
 param = parameters_interface_->get_parameter(param_name);
+RCLCPP_DEBUG_STREAM(logger_, param.get_name() << ": " << param.get_type_name() << " = " << param.value_to_string());
 {% if parameter_validations|length -%}
 {{parameter_validations-}}
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/update_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/update_parameter
@@ -4,5 +4,6 @@ if (param.get_name() == (prefix_ + "{{parameter_name}}")) {
 {{parameter_validations-}}
 {% endif -%}
 updated_params.{{parameter_name}} = param.{{parameter_as_function}};
+RCLCPP_DEBUG_STREAM(logger_, param.get_name() << ": " << param.get_type_name() << " = " << param.value_to_string());
 {% endfilter -%}
 }

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/update_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/update_runtime_parameter
@@ -7,6 +7,7 @@ if (param.get_name() == param_name) {
 {{parameter_validations-}}
 {% endif -%}
 updated_params.{{parameter_map}}[value].{{parameter_field}} = param.{{parameter_as_function}};
+RCLCPP_DEBUG_STREAM(logger_, param.get_name() << ": " << param.get_type_name() << " = " << param.value_to_string());
 {% endfilter -%}
 }
 {% endfilter -%}


### PR DESCRIPTION
Fixes #86

If you build this locally, you can test this by running the example node with debug logging:
```shell
ros2 run generate_parameter_library_example test_node --ros-args --params-file src/generate_parameter_library/example/config/implementation.yaml --log-level debug
```

Then in another terminal change a parameter:
```shell
ros2 param set /admittance_controller control.frame.id new_frame
```

You should see an output like this in the logs:
```
[DEBUG] [1681944620.098785049] [admittance_controller]: control.frame.id: string = new_frame
```