### PR TITLE
ReST: Use correct syntax highlighting

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/default_config
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/default_config
@@ -1,4 +1,4 @@
-.. code::
+.. code:: yaml
 {%- filter indent(width=2) %}
 
 {{namespace}}:


### PR DESCRIPTION
Use the correct markup format in the code block.