### PR TITLE
Fix Python install

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ int main(int argc, char * argv[])
 ```python
 import rclpy
 from rclpy.node import Node
-from turtlesim_parameters import turtlesim_parameters
+from turtlesim_pkg.turtlesim_parameters import turtlesim_parameters
 
 def main(args=None):
   rclpy.init(args=args)

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@
 
 ```
 source install/setup.bash
-ros2 run generate_parameter_library_example test_node --ros-args --params-file --params-file src/generate_parameter_library/examples/cpp/config/implementation.yaml
+ros2 run generate_parameter_library_example test_node --ros-args --params-file src/generate_parameter_library/examples/cpp/config/implementation.yaml
 
 ```
 ## Or run the Python node

--- a/examples/python/generate_parameter_module_example/minimal_publisher.py
+++ b/examples/python/generate_parameter_module_example/minimal_publisher.py
@@ -30,7 +30,7 @@
 import rclpy
 import rclpy.node
 
-from admittance_parameters import admittance_controller
+from generate_parameter_module_example.admittance_parameters import admittance_controller
 
 
 class MinimalParam(rclpy.node.Node):

--- a/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
@@ -40,22 +40,23 @@ def generate_parameter_module(module_name, yaml_file, validation_module=""):
     for i, arg in enumerate(sys.argv):
         # Look for the `--build-directory` option in the command line arguments
         if arg == "--build-directory" or arg == "--build-base":
-            build = sys.argv[i + 1]
+            build_arg = sys.argv[i + 1]
 
-            tmp = os.path.split(build)
-            tmp = os.path.split(tmp[0])
-            pkg_name = tmp[1]
-            tmp = os.path.split(tmp[0])
-            colcon_ws = tmp[0]
+            path_split = os.path.split(build_arg)
+            path_split = os.path.split(path_split[0])
+            pkg_name = path_split[1]
+            path_split = os.path.split(path_split[0])
+            colcon_ws = path_split[0]
+
             tmp = sys.version.split()[0]
             tmp = tmp.split('.')
-
             py_version = f'python{tmp[0]}.{tmp[1]}'
+
             install_dir = os.path.join(colcon_ws, 'install', pkg_name, 'lib', py_version, 'site-packages', pkg_name)
             build_dir = os.path.join(colcon_ws, 'build', pkg_name, pkg_name)
             break
 
     if build_dir:
         run(os.path.join(build_dir, module_name + ".py"), yaml_file, validation_module)
-    if build_dir:
+    if install_dir:
         run(os.path.join(install_dir, module_name + ".py"), yaml_file, validation_module)

--- a/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
@@ -36,12 +36,26 @@ def generate_parameter_module(module_name, yaml_file, validation_module=""):
     # TODO there must be a better way to do this. I need to find the build directory so I can place the python
     # module there
     build_dir = None
+    install_dir = None
     for i, arg in enumerate(sys.argv):
         # Look for the `--build-directory` option in the command line arguments
         if arg == "--build-directory" or arg == "--build-base":
-            build_dir = sys.argv[i + 1]
-            tmp = os.path.split(build_dir)
-            build_dir = os.path.join(*tmp[:-1])
+            build = sys.argv[i + 1]
+
+            tmp = os.path.split(build)
+            tmp = os.path.split(tmp[0])
+            pkg_name = tmp[1]
+            tmp = os.path.split(tmp[0])
+            colcon_ws = tmp[0]
+            tmp = sys.version.split()[0]
+            tmp = tmp.split('.')
+
+            py_version = f'python{tmp[0]}.{tmp[1]}'
+            install_dir = os.path.join(colcon_ws, 'install', pkg_name, 'lib', py_version, 'site-packages', pkg_name)
+            build_dir = os.path.join(colcon_ws, 'build', pkg_name, pkg_name)
             break
+
     if build_dir:
         run(os.path.join(build_dir, module_name + ".py"), yaml_file, validation_module)
+    if build_dir:
+        run(os.path.join(install_dir, module_name + ".py"), yaml_file, validation_module)


### PR DESCRIPTION
This PR fixes the install behavior for colcon build. Now both symlink and non-symlink install correctly and can be imported. Also, I changed the   `admittance_parameters import admittance_controller` to `generate_parameter_module_example.admittance_parameters import admittance_controller`. I believe it's better this way to avoid cluttering the Python namespace. 

There is an unfortunate side effect to installing with symlink. Since the install location is linked to the source, the generated code appears in the project's source code. I don't know if there is any way around this.   