### PR TITLE
Add pyyaml as dependency

### DIFF
--- a/generate_parameter_library_py/setup.py
+++ b/generate_parameter_library_py/setup.py
@@ -36,7 +36,7 @@ setup(
         ),
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
     ],
-    install_requires=["setuptools", "typeguard", "jinja2"],
+    install_requires=["setuptools", "typeguard", "jinja2", "pyyaml"],
     package_data={
         "": [
             "jinja_templates/cpp/declare_parameter",


### PR DESCRIPTION
I don't know exactly what happend, but two weeks ago `sudo python setup.py install` worked in our CI, but now it [doesn't](https://github.com/ros-controls/control.ros.org/actions/runs/5169706099/jobs/9312124488#step:7:82). 

So I [changed the installation](https://github.com/ros-controls/control.ros.org/pull/106) to  `python -m pip install .`, but it [complains for missing yaml module](https://github.com/ros-controls/control.ros.org/actions/runs/5170704614/jobs/9313777855#step:7:83). Adding it to `install_requires` fixed that for me.

