### PR TITLE
Fixed incorrect usage of fmt, causing compile errors

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/cpp_convertions.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/cpp_convertions.py
@@ -92,7 +92,7 @@ class CPPConverstions:
         return (
             f"throw rclcpp::exceptions::InvalidParameterValueException"
             f'(fmt::format("Invalid value set during initialization for '
-            f"parameter '{param_name}': \" + validation_result.error()));"
+            f"parameter '{param_name}': {{}}\", validation_result.error()));"
         )
 
     @typechecked


### PR DESCRIPTION
Just found the library and I really like it. It saves so much time; thank you for your work. There is just a tiny error in the code generator, causing the following error

```
error: temporary of non-literal type ‘std::__cxx11::basic_string<char>’ in a constant expression
  256 |           throw rclcpp::exceptions::InvalidParameterValueException(fmt::format("Invalid value set during initialization for parameter 'led_strip.block_length': " + validation_result.error()));
``` 
The fix is easy, replace the "+ validation_result" with ", validation_result" and add a "{}" for placeholding. That is all this PR does


