### PR TITLE
Remove documentation of deprecated validator functions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,18 +16,19 @@ jobs:
       fail-fast: false
       matrix:
         env:
+          # Werror is not enabled on humble because of gtest
           - ROS_DISTRO: rolling
             ROS_REPO: testing
-            CMAKE_ARGS: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+            CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
           - ROS_DISTRO: rolling
             ROS_REPO: main
-            CMAKE_ARGS: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+            CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
           - ROS_DISTRO: iron
             ROS_REPO: testing
-            CMAKE_ARGS: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+            CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
           - ROS_DISTRO: iron
             ROS_REPO: main
-            CMAKE_ARGS: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+            CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
           - ROS_DISTRO: humble
             ROS_REPO: testing
           - ROS_DISTRO: humble

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          # Werror is not enabled on humble because of gtest
+          # Werror is not enabled on humble and iron because of gtest
           - ROS_DISTRO: rolling
             ROS_REPO: testing
             CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
@@ -25,10 +25,8 @@ jobs:
             CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
           - ROS_DISTRO: iron
             ROS_REPO: testing
-            CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
           - ROS_DISTRO: iron
             ROS_REPO: main
-            CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
           - ROS_DISTRO: humble
             ROS_REPO: testing
           - ROS_DISTRO: humble

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,16 @@ jobs:
         env:
           - ROS_DISTRO: rolling
             ROS_REPO: testing
+            CMAKE_ARGS: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
           - ROS_DISTRO: rolling
             ROS_REPO: main
+            CMAKE_ARGS: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          - ROS_DISTRO: iron
+            ROS_REPO: testing
+            CMAKE_ARGS: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          - ROS_DISTRO: iron
+            ROS_REPO: main
+            CMAKE_ARGS: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
           - ROS_DISTRO: humble
             ROS_REPO: testing
           - ROS_DISTRO: humble

--- a/README.md
+++ b/README.md
@@ -252,12 +252,10 @@ The built-in validator functions provided by this package are:
 | Function               | Arguments           | Description                           |
 |------------------------|---------------------|---------------------------------------|
 | bounds<>               | [lower, upper]      | Bounds checking (inclusive)           |
-| lower_bounds<>         | [lower]             | Lower bounds [Deprecated, use `gt_eq`]|
-| upper_bounds<>         | [upper]             | Upper bounds [Deprecated, use `lt_eq`]|
 | lt<>                   | [value]             | parameter < value                     |
 | gt<>                   | [value]             | parameter > value                     |
-| lt_eq<>                | [value]             | parameter <= value (upper_bounds)     |
-| gt_eq<>                | [value]             | parameter >= value (lower_bounds)     |
+| lt_eq<>                | [value]             | parameter <= value                    |
+| gt_eq<>                | [value]             | parameter >= value                    |
 | one_of<>               | [[val1, val2, ...]] | Value is one of the specified values  |
 
 **String validators**

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(generate_parameter_library_example)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-    add_compile_options(-Werror -Wdeprecated-declarations)
+    add_compile_options(-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(generate_parameter_library_example)
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+    add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(generate_parameter_library REQUIRED)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(generate_parameter_library_example)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-    add_compile_options(-Werror -Wall -Wextra)
+    add_compile_options(-Werror -Wdeprecated-declarations)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(generate_parameter_library_example)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-    add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
+    add_compile_options(-Werror -Wall -Wextra)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/example/include/generate_parameter_library_example/example_validators.hpp
+++ b/example/include/generate_parameter_library_example/example_validators.hpp
@@ -61,8 +61,7 @@ tl::expected<void, std::string> validate_double_array_custom_func(
   return {};
 }
 
-tl::expected<void, std::string> no_args_validator(
-    const rclcpp::Parameter& parameter) {
+tl::expected<void, std::string> no_args_validator(const rclcpp::Parameter&) {
   return {};
 }
 

--- a/example/src/minimal_publisher.cpp
+++ b/example/src/minimal_publisher.cpp
@@ -44,7 +44,7 @@ MinimalPublisher::MinimalPublisher(const rclcpp::NodeOptions& options)
       std::make_shared<ParamListener>(get_node_parameters_interface());
   params_ = param_listener_->get_params();
 
-  StackParams s_params = param_listener_->get_stack_params();
+  [[maybe_unused]] StackParams s_params = param_listener_->get_stack_params();
 
   RCLCPP_INFO(get_logger(), "Initial control frame parameter is: '%s'",
               params_.control.frame.id.c_str());

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -43,8 +43,6 @@ using rsl::element_bounds;
 using rsl::lower_element_bounds;
 using rsl::upper_element_bounds;
 using rsl::bounds;
-using rsl::upper_bounds;
-using rsl::lower_bounds;
 using rsl::lt;
 using rsl::gt;
 using rsl::lt_eq;

--- a/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
@@ -37,7 +37,7 @@ admittance_controller:
     default_value: 1.0,
     description: "proportional gain term",
     validation: {
-      lower_bounds<>: [ 0 ],
+      gt_eq<>: [ 0 ],
     }
   }
 
@@ -55,7 +55,7 @@ admittance_controller:
     default_value: 1.0,
     description: "should be a number less than 10",
     validation: {
-      upper_bounds<>: [ 10 ],
+      lt_eq<>: [ 10 ],
     }
   }
   lt_eq_fifteen: {


### PR DESCRIPTION
`lower_bounds` and `upper_bounds` are deprecated functions and replaced by `lt_eq` and `gt_eq` which do the same thing. This PR removes the documentation of the deprecated functions, they will be deleted in the future but for now there is a deprecation warning in RSL for them.