### PR TITLE
add dependency to python example package

### DIFF
--- a/example_python/package.xml
+++ b/example_python/package.xml
@@ -8,6 +8,7 @@
   <license>BSD-3-Clause</license>
 
   <depend>generate_parameter_library</depend>
+  <depend>generate_parameter_library_py</depend>
   <depend>rclpy</depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
The `setup.py` for the `generate_parameter_module_example` package fails to run when the `generate_parameter_library_py` package is not on the Python path. This PR should fix the issue by adding the dependency to  package.xml.