### PR TITLE
Remove `my_parameter` from python template

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
@@ -30,7 +30,6 @@ stamp_ = Time()
 
     class ParamListener:
         def __init__(self, node, prefix=""):
-            node.declare_parameter('my_parameter', 'world')
             self.prefix_ = prefix
             self.params_ = {{namespace}}.Params()
             self.node_ = node


### PR DESCRIPTION
I have tested your great library for generating parameters for my Python node and noticed that the parameter `my_parameter` was always included. I presume this was accidental.

This PR removes the `my_parameter` from the `parameter_library_header` template.