### PR TITLE
Markdown: Fix sentence for size_lt

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
@@ -54,7 +54,7 @@ class ParameterValidationMarkdown:
             "one_of": "one of the specified values: VALUES",
             "fixed_size": "length must be equal to VALUES",
             "size_gt": "length is greater than VALUES",
-            "size_lt": "length is less less VALUES",
+            "size_lt": "length is less than VALUES",
             "not_empty": "parameter is not empty",
             "unique": "contains no duplicates",
             "subset_of": "every element is one of the list VALUES",


### PR DESCRIPTION
Fixes a simple typo for the markdown validator replacement texts.