### PR TITLE
parse_yaml.py: fix issue with typeguard

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -310,7 +310,7 @@ class ValidationFunction:
     def __init__(
         self,
         function_name: str,
-        arguments: Optional[List[any]],
+        arguments: Optional[List[Any]],
         code_gen_variable: CodeGenVariableBase,
     ):
         self.code_gen_variable = code_gen_variable


### PR DESCRIPTION
Seems like more modern typeguard throws here. This is a fix like already introduced in PR #149.

Fixes this error: (never mind the path names, I changed them)

Traceback (most recent call last):
|   File "/usr/bin/generate_parameter_library_cpp", line 8, in <module>
|     sys.exit(main())
|              ^^^^^^
|   File "/usr/lib/python3.11/site-packages/generate_parameter_library_py/generate_cpp_header.py", line 66, in main
|     run(output_file, yaml_file, validate_header)
|   File "/usr/lib/python3.11/site-packages/generate_parameter_library_py/generate_cpp_header.py", line 45, in run
|     gen_param_struct.parse(yaml_file, validate_header)
|   File "/usr/lib/python3.11/site-packages/generate_parameter_library_py/parse_yaml.py", line 733, in parse
|     self.parse_dict(self.namespace, doc[self.namespace], [])
|   File "/usr/lib/python3.11/site-packages/generate_parameter_library_py/parse_yaml.py", line 831, in parse_dict
|     self.parse_dict(key, root_map[key], nested_name)
|   File "/usr/lib/python3.11/site-packages/generate_parameter_library_py/parse_yaml.py", line 837, in parse_dict
|     self.parse_params(name, root_map, nested_name)
|   File "/usr/lib/python3.11/site-packages/generate_parameter_library_py/parse_yaml.py", line 741, in parse_params
|     ) = preprocess_inputs(self.language, name, value, nested_name_list)
|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|   File "/usr/lib/python3.11/site-packages/generate_parameter_library_py/parse_yaml.py", line 677, in preprocess_inputs
|     validations.append(ValidationFunction(func_name, args, code_gen_variable))
|                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|   File "/usr/lib/python3.11/site-packages/generate_parameter_library_py/parse_yaml.py", line 310, in __init__
|     def __init__(
|   File "/usr/lib/python3.11/site-packages/typeguard/_functions.py", line 113, in check_argument_types
|     check_type_internal(value, expected_type, memo=memo)
|   File "/usr/lib/python3.11/site-packages/typeguard/_checkers.py", line 676, in check_type_internal
|     checker(value, origin_type, args, memo)
|   File "/usr/lib/python3.11/site-packages/typeguard/_checkers.py", line 377, in check_union
|     check_type_internal(value, type_, memo)
|   File "/usr/lib/python3.11/site-packages/typeguard/_checkers.py", line 676, in check_type_internal
|     checker(value, origin_type, args, memo)
|   File "/usr/lib/python3.11/site-packages/typeguard/_checkers.py", line 273, in check_list
|     check_type_internal(v, args[0], memo)
|   File "/usr/lib/python3.11/site-packages/typeguard/_checkers.py", line 679, in check_type_internal
|     if not isinstance(value, origin_type):
|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
| TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union