### PR TITLE
parse_yaml.py: keep the trailing newline

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -870,6 +870,9 @@ class GenerateCode:
             # ),
         }
 
-        j2_template = Template(GenerateCode.templates['parameter_library_header'])
+        j2_template = Template(
+            GenerateCode.templates['parameter_library_header'],
+            keep_trailing_newline=True,
+        )
         code = j2_template.render(data, trim_blocks=True)
         return code


### PR DESCRIPTION
Hi!

I have been using your library for a while and it's really great!

I have a very particular issue that is probably very niche, but I decided to try and fix it. As you can see in the pull request, the fix is very simple.

My use case is very particular, I use docker to prebuild my workspace and then I hop into the container to develop. When prebuilding with `--symlink-install`, this package create the module inside my `src/` directory. 

The problem arise when I mount my workspace inside the container. It essentially wipe the generated modules. The solution I use is to rebuild the packages inside my container and then commit the generated modules.

Which comes to the main point of this pull request, the trailing new line. Since most linter and formatter enforce a newline at the end of a python file by default, the fact that the generated modules don't have one is a little bit annoying.

tl;dr: For the (few) packages that somehow commit the generated modules, adding a trailing newline to the generated module could be a nice quality of life upgrade.