### PR TITLE
markdown/rst: Support __map_ and nested parameters

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
@@ -199,9 +199,9 @@ class AutoDocumentation:
         data = {
             'title': title,
             'default_config': str(self.default_config),
-            'parameter_details': '\n'.join(str(val) for val in self.param_details).join(
-                str(val) for val in self.runtime_param_details
-            ),
+            'parameter_details': '\n'.join(str(val) for val in self.param_details)
+            + '\n'
+            + '\n'.join(str(val) for val in self.runtime_param_details),
         }
 
         j2_template = Template(GenerateCode.templates['documentation'])

--- a/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
@@ -102,11 +102,11 @@ class ParameterDetailMarkdown:
             'type': self.declare_parameters.code_gen_variable.defined_type,
             'default_value': self.declare_parameters.code_gen_variable.lang_str_value,
             'constraints': constraints,
-            # Replace leading whitespaces with two spaces, but preserve newlines
+            # remove leading whitespace from description, this is necessary for correct indentation of multi-line descriptions
             'description': re.sub(
                 r'(?m)^(?!$)\s*',
-                '  ',
-                self.declare_parameters.parameter_description,
+                '',
+                str(self.declare_parameters.parameter_description),
                 flags=re.MULTILINE,
             ),
         }
@@ -138,13 +138,7 @@ class RuntimeParameterDetailMarkdown:
             'type': self.declare_parameters.code_gen_variable.defined_type,
             'default_value': self.declare_parameters.code_gen_variable.lang_str_value,
             'constraints': constraints,
-            # Replace leading whitespaces with two spaces, but preserve newlines
-            'description': re.sub(
-                r'(?m)^(?!$)\s*',
-                '  ',
-                self.declare_parameters.parameter_description,
-                flags=re.MULTILINE,
-            ),
+            'description': self.declare_parameters.parameter_description,
         }
 
         j2_template = Template(GenerateCode.templates['parameter_detail'])

--- a/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
@@ -98,6 +98,7 @@ class ParameterDetailMarkdown:
 
         data = {
             'name': self.declare_parameters.code_gen_variable.name,
+            'read_only': self.declare_parameters.parameter_read_only,
             'type': self.declare_parameters.code_gen_variable.defined_type,
             'default_value': self.declare_parameters.code_gen_variable.lang_str_value,
             'constraints': constraints,
@@ -123,6 +124,7 @@ class ParameterDetailRst:
 
         data = {
             'name': self.declare_parameters.parameter_name,
+            'read_only': self.declare_parameters.parameter_read_only,
             'type': self.declare_parameters.code_gen_variable.defined_type,
             'default_value': self.declare_parameters.code_gen_variable.lang_str_value,
             'constraints': constraints,
@@ -158,6 +160,7 @@ class RuntimeParameterDetailRst:
                 lambda match: '<' + match.group(1) + '>',
                 self.declare_parameters.parameter_name,
             ),
+            'read_only': self.declare_parameters.parameter_read_only,
             'type': self.declare_parameters.code_gen_variable.defined_type,
             'default_value': self.declare_parameters.code_gen_variable.lang_str_value,
             'constraints': constraints,

--- a/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
@@ -97,32 +97,6 @@ class ParameterDetailMarkdown:
         constraints = '\n'.join(str(val) for val in self.param_validations)
 
         data = {
-            'name': self.declare_parameters.code_gen_variable.name,
-            'read_only': self.declare_parameters.parameter_read_only,
-            'type': self.declare_parameters.code_gen_variable.defined_type,
-            'default_value': self.declare_parameters.code_gen_variable.lang_str_value,
-            'constraints': constraints,
-            'description': self.declare_parameters.parameter_description,
-        }
-
-        j2_template = Template(GenerateCode.templates['parameter_detail'])
-        code = j2_template.render(data, trim_blocks=True)
-        return code
-
-
-class ParameterDetailRst:
-    @typechecked
-    def __init__(self, declare_parameters: DeclareParameter):
-        self.declare_parameters = declare_parameters
-        self.param_validations = [
-            ParameterValidationMarkdown(val)
-            for val in declare_parameters.parameter_validations
-        ]
-
-    def __str__(self):
-        constraints = '\n'.join(str(val) for val in self.param_validations)
-
-        data = {
             'name': self.declare_parameters.parameter_name,
             'read_only': self.declare_parameters.parameter_read_only,
             'type': self.declare_parameters.code_gen_variable.defined_type,
@@ -142,7 +116,7 @@ class ParameterDetailRst:
         return code
 
 
-class RuntimeParameterDetailRst:
+class RuntimeParameterDetailMarkdown:
     @typechecked
     def __init__(self, declare_parameters: DeclareRuntimeParameter):
         self.declare_parameters = declare_parameters
@@ -213,6 +187,10 @@ class AutoDocumentation:
             ParameterDetailMarkdown(param)
             for param in self.gen_param_struct.declare_parameters
         ]
+        self.runtime_param_details = [
+            RuntimeParameterDetailMarkdown(param)
+            for param in self.gen_param_struct.declare_dynamic_parameters
+        ]
 
     def __str__(self):
         words = self.gen_param_struct.namespace.split('_')
@@ -221,7 +199,9 @@ class AutoDocumentation:
         data = {
             'title': title,
             'default_config': str(self.default_config),
-            'parameter_details': '\n'.join(str(val) for val in self.param_details),
+            'parameter_details': '\n'.join(str(val) for val in self.param_details).join(
+                str(val) for val in self.runtime_param_details
+            ),
         }
 
         j2_template = Template(GenerateCode.templates['documentation'])

--- a/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
@@ -161,6 +161,16 @@ class DefaultConfigMarkdown:
         tmp = '\n'.join(
             param.parameter_name + ': ' + str(param.code_gen_variable.lang_str_value)
             for param in self.gen_param_struct.declare_parameters
+        ) + '\n'.join(
+            # replace __map_key with <key>
+            re.sub(
+                r'__map_(\w+)',
+                lambda match: '<' + match.group(1) + '>',
+                param.parameter_name,
+            )
+            + ': '
+            + str(param.code_gen_variable.lang_str_value)
+            for param in self.gen_param_struct.declare_dynamic_parameters
         )
 
         data = {

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_parameter
@@ -1,7 +1,7 @@
 if (!parameters_interface_->has_parameter(prefix_ + "{{parameter_name}}")) {
 {%- filter indent(width=4) %}
 rcl_interfaces::msg::ParameterDescriptor descriptor;
-descriptor.description = "{{parameter_description}}";
+descriptor.description = {{parameter_description | valid_string_cpp}};
 descriptor.read_only = {{parameter_read_only}};
 {%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if "DOUBLE" in parameter_type %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_runtime_parameter
@@ -5,7 +5,7 @@ auto param_name = fmt::format("{}{}.{}.{}", prefix_, "{{struct_name}}", value, "
 if (!parameters_interface_->has_parameter(param_name)) {
 {%- filter indent(width=4) %}
 rcl_interfaces::msg::ParameterDescriptor descriptor;
-descriptor.description = "{{parameter_description}}";
+descriptor.description = {{parameter_description | valid_string_cpp}};
 descriptor.read_only = {{parameter_read_only}};
 {%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if "DOUBLE" in parameter_type %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/markdown/parameter_detail
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/markdown/parameter_detail
@@ -4,10 +4,8 @@
 {% endif %}
 * Type: `{{type}}`
 {%- if default_value|length %}
-* Default Value: {{default_value}}
-{% endif %}
+* Default Value: {{default_value}}{% endif %}
 {%- if constraints|length %}
 
 *Constraints:*
-{{constraints}}
-{% endif %}
+{{constraints}}{% endif %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/markdown/parameter_detail
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/markdown/parameter_detail
@@ -4,8 +4,10 @@
 {% endif %}
 * Type: `{{type}}`
 {%- if default_value|length %}
-* Default Value: {{default_value}}{% endif %}
-{%- if constraints|length %}
+* Default Value: {{default_value}}{% endif %}{% if read_only %}
+* Read only: {{read_only}}{% endif %}{%- if constraints|length %}
 
 *Constraints:*
-{{constraints}}{% endif %}
+{{constraints}}
+{% else %}
+{% endif %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/parameter_detail
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/parameter_detail
@@ -1,5 +1,5 @@
 {{name}} ({{type}}){% if description|length %}
-  {{description}}
+{{description}}
 {% endif %}
 {%- if default_value|length %}
   Default:  {{default_value}}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/parameter_detail
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/parameter_detail
@@ -1,15 +1,14 @@
-{{name}} ({{type}}){% if description|length %}
+{{name}} ({{type}}){%- filter indent(width=2) %}{% if description|length %}
 {{description}}
 {% endif %}
 {%- if read_only %}
-  Read only: {{read_only}}
+Read only: {{read_only}}
 {% endif %}
 {%- if default_value|length %}
-  Default:  {{default_value}}
+Default:  {{default_value}}
 {% endif %}
 {%- if constraints|length %}
-
-  Constraints:
+Constraints:
 
 {%- filter indent(width=2) %}
 
@@ -17,3 +16,4 @@
 {% endfilter -%}
 
 {% endif %}
+{% endfilter -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/parameter_detail
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/parameter_detail
@@ -1,6 +1,9 @@
 {{name}} ({{type}}){% if description|length %}
 {{description}}
 {% endif %}
+{%- if read_only %}
+  Read only: {{read_only}}
+{% endif %}
 {%- if default_value|length %}
   Default:  {{default_value}}
 {% endif %}

--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -689,6 +689,18 @@ class GenerateCode:
     templates = None
 
     def __init__(self, language: str):
+        if language == 'cpp':
+            self.comments = '// auto-generated DO NOT EDIT'
+        elif language == 'rst':
+            self.comments = '.. auto-generated DO NOT EDIT'
+        elif language == 'markdown':
+            self.comments = '<!--- auto-generated DO NOT EDIT -->'
+        elif language == 'python' or language == 'markdown':
+            self.comments = '# auto-generated DO NOT EDIT'
+        else:
+            raise compile_error(
+                'Invalid language, only cpp, markdown, rst, and python are currently supported.'
+            )
         GenerateCode.templates = get_all_templates(language)
         self.language = language
         self.namespace = ''
@@ -702,16 +714,6 @@ class GenerateCode:
         self.remove_dynamic_parameter = []
         self.declare_parameter_sets = []
         self.set_stack_params = []
-        if language == 'cpp':
-            self.comments = '// auto-generated DO NOT EDIT'
-        elif language == 'rst':
-            self.comments = '.. auto-generated DO NOT EDIT'
-        elif language == 'python' or language == 'markdown':
-            self.comments = '# auto-generated DO NOT EDIT'
-        else:
-            raise compile_error(
-                'Invalid language, only c++ and python are currently supported.'
-            )
         self.user_validation_file = ''
 
     def parse(self, yaml_file, validate_header):

--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from jinja2 import Template
+from jinja2 import Template, Environment
 from typeguard import typechecked
 from typing import Any, List, Optional
 from yaml.parser import ParserError
@@ -39,6 +39,7 @@ import yaml
 
 from generate_parameter_library_py.cpp_convertions import CPPConverstions
 from generate_parameter_library_py.python_convertions import PythonConvertions
+from generate_parameter_library_py.string_filters_cpp import valid_string_cpp
 
 
 # YAMLSyntaxError standardizes compiler error messages
@@ -499,6 +500,7 @@ class DeclareParameter(DeclareParameterBase):
         bool_to_str = self.code_gen_variable.conversation.bool_to_str
 
         parameter_validations = self.parameter_validations
+
         data = {
             'parameter_name': self.parameter_name,
             'parameter_value': self.parameter_value,
@@ -507,7 +509,11 @@ class DeclareParameter(DeclareParameterBase):
             'parameter_read_only': bool_to_str(self.parameter_read_only),
             'parameter_validations': parameter_validations,
         }
-        j2_template = Template(GenerateCode.templates['declare_parameter'])
+
+        # Create a Jinja2 environment to register the custom filter
+        env = Environment()
+        env.filters['valid_string_cpp'] = valid_string_cpp
+        j2_template = env.from_string(GenerateCode.templates['declare_parameter'])
         code = j2_template.render(data, trim_blocks=True)
         return code
 
@@ -566,7 +572,12 @@ class DeclareRuntimeParameter(DeclareParameterBase):
             'parameter_validations': self.parameter_validations,
         }
 
-        j2_template = Template(GenerateCode.templates['declare_runtime_parameter'])
+        # Create a Jinja2 environment to register the custom filter
+        env = Environment()
+        env.filters['valid_string_cpp'] = valid_string_cpp
+        j2_template = env.from_string(
+            GenerateCode.templates['declare_runtime_parameter']
+        )
         code = j2_template.render(data, trim_blocks=True)
         return code
 

--- a/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+def valid_string_cpp(description):
+    """
+    Filter a string to make it a valid C++ string.
+
+    Args:
+      description (str): The input string to be filtered.
+
+    Returns:
+      str: The filtered string that is a valid C++ string.
+    """
+    filtered_description = (
+        description.replace('\\', '\\\\').replace('"', '\\"').replace('`', '')
+    )
+    # create a quote delimited string for every line
+    filtered_description = '\n'.join(
+        f'"{line}"' for line in filtered_description.splitlines()
+    )
+
+    return filtered_description

--- a/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 def valid_string_cpp(description):
     """
-    Filter a string to make it a valid C++ string.
+    Filter a string to make it a valid C++ string literal.
 
     Args:
       description (str): The input string to be filtered.
@@ -9,12 +9,14 @@ def valid_string_cpp(description):
     Returns:
       str: The filtered string that is a valid C++ string.
     """
-    filtered_description = (
-        description.replace('\\', '\\\\').replace('"', '\\"').replace('`', '')
-    )
-    # create a quote delimited string for every line
-    filtered_description = '\n'.join(
-        f'"{line}"' for line in filtered_description.splitlines()
-    )
-
-    return filtered_description
+    if description:
+        filtered_description = (
+            description.replace('\\', '\\\\').replace('"', '\\"').replace('`', '')
+        )
+        # create a quote delimited string for every line
+        filtered_description = '\n'.join(
+            f'"{line}"' for line in filtered_description.splitlines()
+        )
+        return filtered_description
+    else:
+        return '""'

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -19,8 +19,8 @@ import sys
 import os
 
 from ament_index_python.packages import get_package_share_path
-from generate_parameter_library_py.generate_cpp_header import run as run_python
-from generate_parameter_library_py.generate_python_module import run as run_cpp
+from generate_parameter_library_py.generate_cpp_header import run as run_cpp
+from generate_parameter_library_py.generate_python_module import run as run_python
 from generate_parameter_library_py.generate_markdown import run as run_md
 from generate_parameter_library_py.parse_yaml import YAMLSyntaxError
 from generate_parameter_library_py.generate_cpp_header import parse_args

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -21,6 +21,7 @@ import os
 from ament_index_python.packages import get_package_share_path
 from generate_parameter_library_py.generate_cpp_header import run as run_python
 from generate_parameter_library_py.generate_python_module import run as run_cpp
+from generate_parameter_library_py.generate_markdown import run as run_md
 from generate_parameter_library_py.parse_yaml import YAMLSyntaxError
 from generate_parameter_library_py.generate_cpp_header import parse_args
 
@@ -29,7 +30,7 @@ def set_up(yaml_test_file):
     full_file_path = os.path.join(
         get_package_share_path('generate_parameter_library_py'), 'test', yaml_test_file
     )
-    testargs = [sys.argv[0], '/tmp/admittance_controller.h', full_file_path]
+    testargs = [sys.argv[0], '/tmp/' + yaml_test_file + '.h', full_file_path]
 
     with patch.object(sys, 'argv', testargs):
         args = parse_args()
@@ -37,7 +38,33 @@ def set_up(yaml_test_file):
         yaml_file = args.input_yaml_file
         validate_header = args.validate_header
         run_cpp(output_file, yaml_file, validate_header)
+
+    testargs = [sys.argv[0], '/tmp/' + yaml_test_file + '.py', full_file_path]
+
+    with patch.object(sys, 'argv', testargs):
+        args = parse_args()
+        output_file = args.output_cpp_header_file
+        yaml_file = args.input_yaml_file
+        validate_header = args.validate_header
         run_python(output_file, yaml_file, validate_header)
+
+    testargs = [sys.argv[0], '/tmp/' + yaml_test_file + '.md', full_file_path]
+
+    with patch.object(sys, 'argv', testargs):
+        args = parse_args()
+        output_file = args.output_cpp_header_file
+        yaml_file = args.input_yaml_file
+        validate_header = args.validate_header
+        run_md(yaml_file, output_file, 'markdown')
+
+    testargs = [sys.argv[0], '/tmp/' + yaml_test_file + '.rst', full_file_path]
+
+    with patch.object(sys, 'argv', testargs):
+        args = parse_args()
+        output_file = args.output_cpp_header_file
+        yaml_file = args.input_yaml_file
+        validate_header = args.validate_header
+        run_md(yaml_file, output_file, 'rst')
 
 
 # class TestViewValidCodeGen(unittest.TestCase):


### PR DESCRIPTION
This closes #118 and closes #126.

I had to write a custom jinja2 filter `valid_string_cpp` to create valid c++ string literals for multi-line descriptions.

This also adds rudimentary support for the default config:
```yaml
joint_trajectory_controller:
  ros__parameters:
    action_monitor_rate: 20.0
    allow_integration_in_goal_trajectories: false
    allow_nonzero_velocity_at_trajectory_end: false
    allow_partial_joints_goal: false
    cmd_timeout: 0.0
    command_interfaces: '{}'
    command_joints: '{}'
    constraints:
      <joints>:
        goal: 0.0
        trajectory: 0.0
      goal_time: 0.0
      stopped_velocity_tolerance: 0.01
    gains:
      <joints>:
        angle_wraparound: false
        d: 0.0
        ff_velocity_scale: 0.0
        i: 0.0
        i_clamp: 0.0
        p: 0.0
    interpolation_method: splines
    joints: '{}'
    open_loop_control: false
    state_interfaces: '{}'
```

Would there be any possibility to add a description to a top-level of the nested structure? I didn't manage to write correct yaml syntax for that. Maybe this would have to be solved with a new type "struct", just for documentation purposes?
Example is the description of "constraints" here:
![image](https://github.com/PickNikRobotics/generate_parameter_library/assets/3367244/8faa9dc0-5341-4576-a5c7-a59e6ad95c29)
