### PR TITLE
Fix Python runtime parameters bug

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_struct
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_struct
@@ -13,7 +13,8 @@ class __{{struct_name}}:
 {% if not struct_instance|length -%}
 __map_type = __{{struct_name}}
 def add_entry(self, name):
-    setattr(self, name, self.__map_type())
+    if not hasattr(self, name):
+        setattr(self, name, self.__map_type())
 def get_entry(self, name):
-    return getattr(self, name, self.__map_type())
+    return getattr(self, name)
 {% endif -%}


### PR DESCRIPTION
A description of a bug with Python runtime parameters is detailed here https://github.com/PickNikRobotics/generate_parameter_library/issues/163. This PR fixes the issue by preventing default initialized value from being created every time a parameter is accessed.  