### PR TITLE
Update `cmake_minimum_required` to 3.20

### DIFF
--- a/generate_parameter_library/CMakeLists.txt
+++ b/generate_parameter_library/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 project(generate_parameter_library NONE)
 
 # find dependencies


### PR DESCRIPTION
With #171 I realized that this library has a wrong `cmake_minimum_required` declaration, `cmake_path` is available only from 3.20 on:
https://cmake.org/cmake/help/latest/command/cmake_path.html