### PR TITLE
Fix typo in `update_interal_params`

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -169,7 +169,7 @@ struct StackParams {
       }
 {%- endif %}
       updated_params.__stamp = clock_.now();
-      update_interal_params(updated_params);
+      update_internal_params(updated_params);
       return rsl::to_parameter_result_msg({});
     }
 
@@ -193,11 +193,11 @@ struct StackParams {
 {%- endif %}
 
       updated_params.__stamp = clock_.now();
-      update_interal_params(updated_params);
+      update_internal_params(updated_params);
     }
 
     private:
-      void update_interal_params(Params updated_params) {
+      void update_internal_params(Params updated_params) {
         std::lock_guard<std::mutex> lock(mutex_);
         params_ = updated_params;
       }


### PR DESCRIPTION
When looking at generated code, I noticed there was a member function generated named `update_interal_params` which should be `update_internal_params`.