### PR TITLE
Fix test on rolling CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,8 @@ jobs:
           # Werror is not enabled on humble and iron because of gtest
           - ROS_DISTRO: rolling
             ROS_REPO: testing
-            CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
           - ROS_DISTRO: rolling
             ROS_REPO: main
-            CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-Werror
           - ROS_DISTRO: iron
             ROS_REPO: testing
           - ROS_DISTRO: iron

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          # Werror is not enabled on humble and iron because of gtest
           - ROS_DISTRO: rolling
             ROS_REPO: testing
           - ROS_DISTRO: rolling

--- a/generate_parameter_library_py/generate_parameter_library_py/cpp_convertions.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/cpp_convertions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import List, Optional
+from typing import List, Union
 from jinja2 import Template
 from typeguard import typechecked
 import os
@@ -108,18 +108,18 @@ class CPPConverstions:
         return ''
 
     @typechecked
-    def no_code(self, s: Optional[str]):
+    def no_code(self, s: Union[None, str]):
         return ''
 
     # value to c++ string conversion functions
     @typechecked
-    def bool_to_str(self, cond: Optional[bool]):
+    def bool_to_str(self, cond: Union[None, bool]):
         if cond is None:
             return ''
         return 'true' if cond else 'false'
 
     @typechecked
-    def float_to_str(self, num: Optional[float]):
+    def float_to_str(self, num: Union[None, float]):
         if num is None:
             return ''
         str_num = str(num)
@@ -136,65 +136,65 @@ class CPPConverstions:
         return str_num
 
     @typechecked
-    def int_to_str(self, num: Optional[int]):
+    def int_to_str(self, num: Union[None, int]):
         if num is None:
             return ''
         return str(num)
 
     @typechecked
-    def str_to_str(self, s: Optional[str]):
+    def str_to_str(self, s: Union[None, str]):
         if s is None:
             return ''
         return f'"{s}"'
 
     @typechecked
-    def bool_array_to_str(self, values: Optional[list]):
+    def bool_array_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '{' + ', '.join(self.bool_to_str(x) for x in values) + '}'
 
     @typechecked
-    def float_array_to_str(self, values: Optional[list]):
+    def float_array_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '{' + ', '.join(self.float_to_str(x) for x in values) + '}'
 
     @typechecked
-    def int_array_to_str(self, values: Optional[list]):
+    def int_array_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '{' + ', '.join(self.int_to_str(x) for x in values) + '}'
 
     @typechecked
-    def str_array_to_str(self, s: Optional[list]):
+    def str_array_to_str(self, s: Union[None, list]):
         if s is None:
             return ''
         return '{' + ', '.join(self.str_to_str(x) for x in s) + '}'
 
     @typechecked
-    def str_array_fixed_to_str(self, s: Optional[list]):
+    def str_array_fixed_to_str(self, s: Union[None, list]):
         raise compile_error('not implemented')
 
     @typechecked
-    def str_fixed_to_str(self, s: Optional[str]):
+    def str_fixed_to_str(self, s: Union[None, str]):
         if s is None:
             return ''
         return '{%s}' % self.str_to_str(s)
 
     @typechecked
-    def float_array_fixed_to_str(self, values: Optional[list]):
+    def float_array_fixed_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '{{' + ', '.join(self.float_to_str(x) for x in values) + '}}'
 
     @typechecked
-    def int_array_fixed_to_str(self, values: Optional[list]):
+    def int_array_fixed_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '{{' + ', '.join(self.int_to_str(x) for x in values) + '}}'
 
     @typechecked
-    def bool_array_fixed_to_str(self, values: Optional[list]):
+    def bool_array_fixed_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '{{' + ', '.join(self.bool_to_str(x) for x in values) + '}}'

--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -37,7 +37,7 @@ try:
 except:
     TypeCheckError = TypeError
 
-from typing import Any, List, Optional
+from typing import Any, List, Union
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
 import os
@@ -320,7 +320,7 @@ class ValidationFunction:
     def __init__(
         self,
         function_name: str,
-        arguments: Optional[List[Any]],
+        arguments: Union[None, List[Any]],
         code_gen_variable: CodeGenVariableBase,
     ):
         self.code_gen_variable = code_gen_variable

--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -31,6 +31,12 @@
 
 from jinja2 import Template, Environment
 from typeguard import typechecked
+
+try:
+    from typeguard import TypeCheckError
+except:
+    TypeCheckError = TypeError
+
 from typing import Any, List, Optional
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
@@ -190,7 +196,7 @@ class CodeGenVariableBase:
         func = self.conversation.lang_str_value_func[self.defined_type]
         try:
             self.lang_str_value = func(default_value)
-        except TypeError:
+        except TypeCheckError:
             raise compile_error(
                 f'Parameter {param_name} has incorrect type. Expected: {defined_type}, got: {self.get_yaml_type_from_python(default_value)}'
             )

--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -32,9 +32,11 @@
 from jinja2 import Template, Environment
 from typeguard import typechecked
 
+# try to import TypeCheckError from typeguard. This was breaking and replaced TypeError in 3.0.0
 try:
     from typeguard import TypeCheckError
-except:
+except ImportError as e:
+    # otherwise, use the old TypeError
     TypeCheckError = TypeError
 
 from typing import Any, List, Union

--- a/generate_parameter_library_py/generate_parameter_library_py/python_convertions.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/python_convertions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import List, Optional
+from typing import List, Union
 from jinja2 import Template
 from typeguard import typechecked
 import os
@@ -107,18 +107,18 @@ class PythonConvertions:
         return ''
 
     @typechecked
-    def no_code(self, s: Optional[str]):
+    def no_code(self, s: Union[None, str]):
         return ''
 
     # value to c++ string conversion functions
     @typechecked
-    def bool_to_str(self, cond: Optional[bool]):
+    def bool_to_str(self, cond: Union[None, bool]):
         if cond is None:
             return ''
         return 'True' if cond else 'False'
 
     @typechecked
-    def float_to_str(self, num: Optional[float]):
+    def float_to_str(self, num: Union[None, float]):
         if num is None:
             return ''
         str_num = str(num)
@@ -135,65 +135,65 @@ class PythonConvertions:
         return str_num
 
     @typechecked
-    def int_to_str(self, num: Optional[int]):
+    def int_to_str(self, num: Union[None, int]):
         if num is None:
             return ''
         return str(num)
 
     @typechecked
-    def str_to_str(self, s: Optional[str]):
+    def str_to_str(self, s: Union[None, str]):
         if s is None:
             return ''
         return f'"{s}"'
 
     @typechecked
-    def bool_array_to_str(self, values: Optional[list]):
+    def bool_array_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '[' + ', '.join(self.bool_to_str(x) for x in values) + ']'
 
     @typechecked
-    def float_array_to_str(self, values: Optional[list]):
+    def float_array_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '[' + ', '.join(self.float_to_str(x) for x in values) + ']'
 
     @typechecked
-    def int_array_to_str(self, values: Optional[list]):
+    def int_array_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '[' + ', '.join(self.int_to_str(x) for x in values) + ']'
 
     @typechecked
-    def str_array_to_str(self, s: Optional[list]):
+    def str_array_to_str(self, s: Union[None, list]):
         if s is None:
             return ''
         return '[' + ', '.join(self.str_to_str(x) for x in s) + ']'
 
     @typechecked
-    def str_array_fixed_to_str(self, s: Optional[list]):
+    def str_array_fixed_to_str(self, s: Union[None, list]):
         raise compile_error('not implemented')
 
     @typechecked
-    def str_fixed_to_str(self, s: Optional[str]):
+    def str_fixed_to_str(self, s: Union[None, str]):
         if s is None:
             return ''
         return '%s' % self.str_to_str(s)
 
     @typechecked
-    def float_array_fixed_to_str(self, values: Optional[list]):
+    def float_array_fixed_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '[' + ', '.join(self.float_to_str(x) for x in values) + ']'
 
     @typechecked
-    def int_array_fixed_to_str(self, values: Optional[list]):
+    def int_array_fixed_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '[' + ', '.join(self.int_to_str(x) for x in values) + ']'
 
     @typechecked
-    def bool_array_fixed_to_str(self, values: Optional[list]):
+    def bool_array_fixed_to_str(self, values: Union[None, list]):
         if values is None:
             return ''
         return '[' + ', '.join(self.bool_to_str(x) for x in values) + ']'

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -81,6 +81,11 @@ def set_up(yaml_test_file):
     ],
 )
 def test_expected(test_input, expected):
+    if sys.flags.optimize:
+        if test_input == 'wrong_default_type.yaml':
+            pytest.skip(
+                'Evaluating optimized type validation cannot be completed when python is optimized'
+            )
     with pytest.raises(expected) as e:
         yaml_test_file = test_input
         set_up(yaml_test_file)

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -86,6 +86,7 @@ def test_expected(test_input, expected):
             pytest.skip(
                 'Evaluating optimized type validation cannot be completed when python is optimized'
             )
+
     with pytest.raises(expected) as e:
         yaml_test_file = test_input
         set_up(yaml_test_file)

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -81,7 +81,7 @@ def set_up(yaml_test_file):
     ],
 )
 def test_expected(test_input, expected):
-    if sys.flags.optimize:
+    if not __debug__ or sys.flags.optimize:
         if test_input == 'wrong_default_type.yaml':
             pytest.skip(
                 'Evaluating optimized type validation cannot be completed when python is optimized'

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -81,12 +81,6 @@ def set_up(yaml_test_file):
     ],
 )
 def test_expected(test_input, expected):
-    if not __debug__ or sys.flags.optimize:
-        if test_input == 'wrong_default_type.yaml':
-            pytest.skip(
-                'Evaluating optimized type validation cannot be completed when python is optimized'
-            )
-
     with pytest.raises(expected) as e:
         yaml_test_file = test_input
         set_up(yaml_test_file)


### PR DESCRIPTION
It appears that the CI for rolling might be running Python with optimization. This disables type checks causing a test to fail. This PR disables the test if the environment is set to optimize.