### PR TITLE
Drop yaml brackets for consistency and readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,30 +22,24 @@ Write a yaml file to declare your parameters and their attributes.
 ```yaml
 turtlesim:
   background:
-    r: {
-      type: int,
-      default_value: 0,
-      description: "Red color value for the background, 8-bit",
-      validation: {
+    r:
+      type: int
+      default_value: 0
+      description: "Red color value for the background, 8-bit"
+      validation:
         bounds<>: [0, 255]
-      }
-    }
-    g: {
-      type: int,
-      default_value: 0,
-      description: "Green color value for the background, 8-bit",
-      validation: {
+    g:
+      type: int
+      default_value: 0
+      description: "Green color value for the background, 8-bit"
+      validation:
         bounds<>: [0, 255]
-      }
-    }
-    b: {
-      type: int,
-      default_value: 0,
-      description: "Blue color value for the background, 8-bit",
-      validation: {
+    b:
+      type: int
+      default_value: 0
+      description: "Blue color value for the background, 8-bit"
+      validation:
         bounds<>: [0, 255]
-      }
-    }
 ```
 
 ### Add parameter library generation to project
@@ -177,14 +171,13 @@ A leaf represents a single parameter and has the following format.
 
 ```yaml
 cpp_namespace:
-  param_name: {
-    type: int,
-    default_value: 3,
-    read_only: true,
-    description: "A read-only  integer parameter with a default value of 3",
+  param_name:
+    type: int
+    default_value: 3
+    read_only: true
+    description: "A read-only  integer parameter with a default value of 3"
     validation:
       # validation functions ...
-  }
 ```
 
 A parameter is a YAML dictionary with the only required key being `type`.
@@ -226,15 +219,13 @@ If the function does not take any values you write `null` or `[]` to for the val
 
 ```yaml
 joint_trajectory_controller:
-  command_interfaces: {
-    type: string_array,
-    description: "Names of command interfaces to claim",
-    validation: {
-      size_gt<>: [0],
-      unique<>: null,
-      subset_of<>: [["position", "velocity", "acceleration", "effort",]],
-    }
-  }
+  command_interfaces:
+    type: string_array
+    description: "Names of command interfaces to claim"
+    validation:
+      size_gt<>: [0]
+      unique<>: null
+      subset_of<>: [["position", "velocity", "acceleration", "effort",]]
 ```
 
 Above are validations for `command_interfaces` from `ros2_controllers`.
@@ -299,9 +290,8 @@ tl::expected<void, std::string> integer_equal_value(
   int param_value = parameter.as_int();
     if (param_value != expected_value) {
         return tl::make_unexpected(fmt::format(
-            "Invalid value {} for parameter {}. Expected {}",
+            "Invalid value {} for parameter {}. Expected {}"
             param_value, parameter.get_name(), expected_value);
-    }
 
   return {};
 }
@@ -310,7 +300,7 @@ tl::expected<void, std::string> integer_equal_value(
 ```
 To configure a parameter to be validated with the custom validator function `integer_equal_value` with an `expected_value` of `3` you could would this to the YAML.
 ```yaml
-validation: {
+validation:
   "my_project::integer_equal_value": [3]
 }
 ```
@@ -323,9 +313,8 @@ the same name as the key.
 cpp_name_space:
   nest1:
     nest2:
-      param_name: { # this is a leaf
+      param_name: # this is a leaf
         type: string_array
-      }
 ```
 
 The generated parameter value can then be accessed with `params.nest1.nest2.param_name`
@@ -335,29 +324,25 @@ You can use parameter maps, where a map with keys from another `string_array` pa
 
 ```yaml
 cpp_name_space:
-  joints: {
-    type: string_array,
-    default_value: ["joint1", "joint2", "joint3"],
-    description: "specifies which joints will be used by the controller",
-  }
-  interfaces: {
-    type: string_array,
-    default_value: ["position", "velocity", "acceleration"],
-    description: "interfaces to be used by the controller",
-  }
+  joints:
+    type: string_array
+    default_value: ["joint1", "joint2", "joint3"]
+    description: "specifies which joints will be used by the controller"
+  interfaces:
+    type: string_array
+    default_value: ["position", "velocity", "acceleration"]
+    description: "interfaces to be used by the controller"
   # nested mapped example
   gain:
     __map_joints: # create a map with joints as keys
       __map_interfaces:  # create a map with interfaces as keys
-        value: {
+        value:
           type: double
-        }
   # simple mapped example
   pid:
     __map_joints: # create a map with joints as keys
-      values: {
+      values:
         type: double_array
-      }
 ```
 
 The generated parameter value for the nested map example can then be accessed with `params.gain.joints_map.at("joint1").interfaces_map.at("position").value`.
@@ -396,20 +381,17 @@ Example of declarative YAML
 
 ```yaml
 force_torque_broadcaster_controller:
-  sensor_name: {
-    type: string,
-    default_value: "",
-    description: "Name of the sensor used as prefix for interfaces if there are no individual interface names defined.",
-  }
-  frame_id: {
-    type: string,
-    default_value: "",
-    description: "Sensor's frame_id in which values are published.",
-  }
-  sensor_filter_chain: {
-    type: none,
-    description: "Map of parameters that defines a filter chain, containing filterN as key and underlying map of parameters needed for a specific filter. See <some docs> for more details.",
-  }
+  sensor_name:
+    type: string
+    default_value: ""
+    description: "Name of the sensor used as prefix for interfaces if there are no individual interface names defined."
+  frame_id:
+    type: string
+    default_value: ""
+    description: "Sensor's frame_id in which values are published."
+  sensor_filter_chain:
+    type: none
+    description: "Map of parameters that defines a filter chain, containing filterN as key and underlying map of parameters needed for a specific filter. See <some docs> for more details."
 ```
 
 Example of parameters for that controller

--- a/README.md
+++ b/README.md
@@ -302,7 +302,6 @@ To configure a parameter to be validated with the custom validator function `int
 ```yaml
 validation:
   "my_project::integer_equal_value": [3]
-}
 ```
 
 ### Nested structures

--- a/example/src/parameters.yaml
+++ b/example/src/parameters.yaml
@@ -1,334 +1,267 @@
 admittance_controller:
-  scientific_notation_num: {
-    type: double,
-    default_value: 0.00000000001,
-    description: "Test scientific notation",
-  }
-  interpolation_mode: {
-    type: string,
-    default_value: "spline",
-    description: "specifies which algorithm to use for interpolation.",
-    validation: {
-      one_of<>: [ [ "spline", "linear" ] ],
+  scientific_notation_num:
+    type: double
+    default_value: 0.00000000001
+    description: "Test scientific notation"
+  interpolation_mode:
+    type: string
+    default_value: "spline"
+    description: "specifies which algorithm to use for interpolation."
+    validation:
+      one_of<>: [ [ "spline", "linear" ] ]
       "custom_validators::no_args_validator": null
-    }
-  }
-  joints: {
-    type: string_array,
-    default_value: ["joint1", "joint2", "joint3"],
-    description: "specifies which joints will be used by the controller",
-  }
-  dof_names: {
-    type: string_array,
-    default_value: ["x", "y", "rz"],
-    description: "specifies which joints will be used by the controller",
-  }
+  joints:
+    type: string_array
+    default_value: ["joint1", "joint2", "joint3"]
+    description: "specifies which joints will be used by the controller"
+  dof_names:
+    type: string_array
+    default_value: ["x", "y", "rz"]
+    description: "specifies which joints will be used by the controller"
 
   __map_joints:
     __map_dof_names:
-      weight: {
-        type: double,
-        default_value: 1.0,
-        description: "map parameter without struct name",
-        validation: {
-          gt<>: [0.0],
-        }
-      }
+      weight:
+        type: double
+        default_value: 1.0
+        description: "map parameter without struct name"
+        validation:
+          gt<>: [0.0]
 
   nested_dynamic:
     __map_joints:
       __map_dof_names:
-        nested: {
-          type: double,
-          default_value: 1.0,
-          description: "test nested map params",
-          validation: {
-            gt_eq<>: [ 0.0001 ],
-          }
-        }
+        nested:
+          type: double
+          default_value: 1.0
+          description: "test nested map params"
+          validation:
+            gt_eq<>: [ 0.0001 ]
         __map_joints:
           __map_dof_names:
-            nested_deep: {
-              type: double,
-              default_value: 1.0,
-              description: "test deep nested map params",
-              validation: {
-                gt_eq<>: [ 0.0001 ],
-              }
-            }
+            nested_deep:
+              type: double
+              default_value: 1.0
+              description: "test deep nested map params"
+              validation:
+                gt_eq<>: [ 0.0001 ]
 
   pid:
-    rate: {
-      type: double,
-      default_value: 0.005,
+    rate:
+      type: double
+      default_value: 0.005
       description: "update loop period in seconds"
 
-    }
     __map_joints:
-      p: {
-        type: double,
-        default_value: 1.0,
-        description: "proportional gain term",
-        validation: {
-          gt_eq<>: [ 0.0001 ],
-        }
-      }
-      i: {
-        type: double,
-        default_value: 1.0,
+      p:
+        type: double
+        default_value: 1.0
+        description: "proportional gain term"
+        validation:
+          gt_eq<>: [ 0.0001 ]
+      i:
+        type: double
+        default_value: 1.0
         description: "integral gain term"
-      }
-      d: {
-        type: double,
-        default_value: 1.0,
+      d:
+        type: double
+        default_value: 1.0
         description: "derivative gain term"
-      }
 
   gains:
     __map_dof_names:
-      k: {
-        type: double,
-        default_value: 2.0,
+      k:
+        type: double
+        default_value: 2.0
         description: "general gain"
-      }
 
-  fixed_string: {
-    type: string_fixed_25,
-    default_value: "string_value",
-    description: "test code generation for fixed sized string",
-  }
-  fixed_array: {
-    type: double_array_fixed_10,
-    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3],
-    description: "test code generation for fixed sized array",
-  }
-  fixed_string_no_default: {
-    type: string_fixed_25,
-    description: "test code generation for fixed sized string with no default",
-  }
+  fixed_string:
+    type: string_fixed_25
+    default_value: "string_value"
+    description: "test code generation for fixed sized string"
+  fixed_array:
+    type: double_array_fixed_10
+    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3]
+    description: "test code generation for fixed sized array"
+  fixed_string_no_default:
+    type: string_fixed_25
+    description: "test code generation for fixed sized string with no default"
   command_interfaces:
-    {
-      type: string_array,
-      description: "specifies which command interfaces to claim",
+      type: string_array
+      description: "specifies which command interfaces to claim"
       read_only: true
-    }
 
   state_interfaces:
-    {
-      type: string_array,
-      description: "specifies which state interfaces to claim",
+      type: string_array
+      description: "specifies which state interfaces to claim"
       read_only: true
-    }
 
   chainable_command_interfaces:
-    {
-      type: string_array,
-      description: "specifies which chainable interfaces to claim",
+      type: string_array
+      description: "specifies which chainable interfaces to claim"
       read_only: true
-    }
 
   kinematics:
-    plugin_name: {
-      type: string,
+    plugin_name:
+      type: string
       description: "specifies which kinematics plugin to load"
-    }
-    plugin_package: {
-      type: string,
+    plugin_package:
+      type: string
       description: "specifies the package to load the kinematics plugin from"
-    }
-    base: {
-      type: string,
+    base:
+      type: string
       description: "specifies the base link of the robot description used by the kinematics plugin"
-    }
-    tip: {
-      type: string,
+    tip:
+      type: string
       description: "specifies the end effector link of the robot description used by the kinematics plugin"
-    }
-    alpha: {
-      type: double,
-      default_value: 0.0005,
+    alpha:
+      type: double
+      default_value: 0.0005
       description: "specifies the damping coefficient for the Jacobian pseudo inverse"
-    }
-    group_name: {
-      type: string,
+    group_name:
+      type: string
       description: "specifies the group name for planning with Moveit"
-    }
 
   ft_sensor:
-    name: {
-      type: string,
+    name:
+      type: string
       description: "name of the force torque sensor in the robot description"
-    }
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "frame of the force torque sensor"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the force torque sensor is contained in the kinematics chain from the base to the tip"
-      }
-    filter_coefficient: {
-      type: double,
-      default_value: 0.005,
+    filter_coefficient:
+      type: double
+      default_value: 0.005
       description: "specifies the coefficient for the sensor's exponential filter"
-    }
 
   control:
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "control frame used for admittance control"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the control frame is contained in the kinematics chain from the base to the tip"
-      }
 
   fixed_world_frame: # Gravity points down (neg. Z) in this frame (Usually: world or base_link)
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "world frame, gravity points down (neg. Z) in this frame"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the world frame is contained in the kinematics chain from the base to the tip"
-      }
 
   gravity_compensation:
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "frame which center of gravity (CoG) is defined in"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the center of gravity frame is contained in the kinematics chain from the base to the tip"
-      }
     CoG: # specifies the center of gravity of the end effector
-      pos: {
-        type: double_array,
-        description: "position of the center of gravity (CoG) in its frame",
-        validation: {
+      pos:
+        type: double_array
+        description: "position of the center of gravity (CoG) in its frame"
+        validation:
           fixed_size<>: 3
-        }
-      }
-      force: {
-        type: double,
-        default_value: .NAN,
+      force:
+        type: double
+        default_value: .NAN
         description: "weight of the end effector, e.g mass * 9.81"
-      }
 
   admittance:
     selected_axes:
-      {
-        type: bool_array,
-        description: "specifies if the axes x, y, z, rx, ry, and rz are enabled",
-        validation: {
+        type: bool_array
+        description: "specifies if the axes x, y, z, rx, ry, and rz are enabled"
+        validation:
           fixed_size<>: 6
-        }
-      }
 
     # Having ".0" at the end is MUST, otherwise there is a loading error
     # F = M*a + D*v + S*(x - x_d)
-    mass: {
-      type: double_array,
-      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation",
-      validation: {
-        fixed_size<>: 6,
+    mass:
+      type: double_array
+      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation"
+      validation:
+        fixed_size<>: 6
         element_bounds<>: [ 0.0001, 1000000.0 ]
-      }
-    }
 
-    damping_ratio: {
-      type: double_array,
+    damping_ratio:
+      type: double_array
       description: "specifies damping ratio values for x, y, z, rx, ry, and rz used in the admittance calculation.
-      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))",
-      validation: {
-        fixed_size<>: 6,
-        "custom_validators::validate_double_array_custom_func": [ 20.3, 5.0 ],
+      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))"
+      validation:
+        fixed_size<>: 6
+        "custom_validators::validate_double_array_custom_func": [ 20.3, 5.0 ]
         element_bounds<>: [ 0.1, 10.0 ]
-      }
-    }
 
-    stiffness: {
-      type: double_array,
-      description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation",
-      validation: {
+    stiffness:
+      type: double_array
+      description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation"
+      validation:
         element_bounds: [ 0.0001, 100000.0 ]
-      }
-    }
 
   # general settings
-  enable_parameter_update_without_reactivation: {
-    type: bool,
-    default_value: true,
+  enable_parameter_update_without_reactivation:
+    type: bool
+    default_value: true
     description: "if enabled, read_only parameters will be dynamically updated in the control loop"
-  }
-  use_feedforward_commanded_input: {
-    type: bool,
-    default_value: false,
+  use_feedforward_commanded_input:
+    type: bool
+    default_value: false
     description: "if enabled, the velocity commanded to the admittance controller is added to its calculated admittance velocity"
-  }
-  lt_eq_fifteen: {
-    type: int,
-    default_value: 1,
-    description: "should be a number less than or equal to 15",
-    validation: {
-      lt_eq<>: [ 15 ],
-    }
-  }
-  gt_fifteen: {
-    type: int,
-    default_value: 16,
-    description: "should be a number greater than 15",
-    validation: {
-      gt<>: [ 15 ],
-    }
-  }
-  one_number: {
-    type: int,
-    default_value: 14540,
-    read_only: true,
-    validation: {
+  lt_eq_fifteen:
+    type: int
+    default_value: 1
+    description: "should be a number less than or equal to 15"
+    validation:
+      lt_eq<>: [ 15 ]
+  gt_fifteen:
+    type: int
+    default_value: 16
+    description: "should be a number greater than 15"
+    validation:
+      gt<>: [ 15 ]
+  one_number:
+    type: int
+    default_value: 14540
+    read_only: true
+    validation:
       bounds<>: [ 1024, 65535 ]
-    }
-  }
-  three_numbers: {
-    type: int_array,
-    default_value: [3,4,5],
-    read_only: true,
-  }
-  three_numbers_of_five: {
-    type: int_array_fixed_5,
-    default_value: [3,3,3],
-    read_only: true,
-  }
-  hover_override: {
-    type: int,
-    default_value: 1,
-    description: "Override hover action:\n0: Hover\n1: Push\n2: Pull\n-1: Do not override",
-    validation: {
-      one_of<>: [ [ 0, 1, 2, -1 ] ],
-    },
-  }
-  angle_wraparound: {
-    type: bool,
-    default_value: false,
-    description: 'For joints that wrap around (without end stop, ie. are continuous),
+  three_numbers:
+    type: int_array
+    default_value: [3,4,5]
+    read_only: true
+  three_numbers_of_five:
+    type: int_array_fixed_5
+    default_value: [3,3,3]
+    read_only: true
+  hover_override:
+    type: int
+    default_value: 1
+    description: "Override hover action:\n0: Hover\n1: Push\n2: Pull\n-1: Do not override"
+    validation:
+      one_of<>: [ [ 0, 1, 2, -1 ] ]
+  angle_wraparound:
+    type: bool
+    default_value: false
+    description: 'For joints that wrap around (without end stop, ie. are continuous)
           where the shortest rotation to the target position is the desired motion.
           If true, the position error :math:`e = normalize(s_d - s)` is normalized between :math:`-\pi, \pi`.
           Otherwise  :math:`e = s_d - s` is used, with the desired position :math:`s_d` and the measured
           position :math:`s` from the state interface.'
-  }
-  open_loop_control: {
-    type: bool,
-    default_value: false,
+  open_loop_control:
+    type: bool
+    default_value: false
     description: "Use controller in open-loop control mode
         \n\n
         * The controller ignores the states provided by hardware interface but using last commands as states for starting the trajectory interpolation.\n
@@ -338,6 +271,5 @@ admittance_controller:
         \n\n
         If this flag is set, the controller tries to read the values from the command interfaces on activation.
         If they have real numeric values, those will be used instead of state interfaces.
-        Therefore it is important set command interfaces to NaN (i.e., ``std::numeric_limits<double>::quiet_NaN()``) or state values when the hardware is started.\n",
-    read_only: true,
-  }
+        Therefore it is important set command interfaces to NaN (i.e., ``std::numeric_limits<double>::quiet_NaN()``) or state values when the hardware is started.\n"
+    read_only: true

--- a/example_cmake_python/cmake_generate_parameter_module_example/parameters.yaml
+++ b/example_cmake_python/cmake_generate_parameter_module_example/parameters.yaml
@@ -1,286 +1,226 @@
 admittance_controller:
-  scientific_notation_num: {
-    type: double,
-    default_value: 0.00000000001,
-    description: "Test scientific notation",
-  }
-  interpolation_mode: {
-    type: string,
-    default_value: "spline",
-    description: "specifies which algorithm to use for interpolation.",
-    validation: {
-      one_of<>: [ [ "spline", "linear" ] ],
+  scientific_notation_num:
+    type: double
+    default_value: 0.00000000001
+    description: "Test scientific notation"
+  interpolation_mode:
+    type: string
+    default_value: "spline"
+    description: "specifies which algorithm to use for interpolation."
+    validation:
+      one_of<>: [ [ "spline", "linear" ] ]
       "custom_validators::no_args_validator": null
-    }
-  }
-  subset_selection: {
-    type: string_array,
-    default_value: ["A", "B"],
-    description: "test subset of validator.",
-    validation: {
-      subset_of<>: [ [ "A", "B", "C"] ],
-      }
-  }
-  joints: {
-    type: string_array,
-    default_value: ["joint1", "joint2", "joint3"],
-    description: "specifies which joints will be used by the controller",
-  }
-  dof_names: {
-    type: string_array,
-    default_value: ["x", "y", "rz"],
-    description: "specifies which joints will be used by the controller",
-  }
+  subset_selection:
+    type: string_array
+    default_value: ["A", "B"]
+    description: "test subset of validator."
+    validation:
+      subset_of<>: [ [ "A", "B", "C"] ]
+  joints:
+    type: string_array
+    default_value: ["joint1", "joint2", "joint3"]
+    description: "specifies which joints will be used by the controller"
+  dof_names:
+    type: string_array
+    default_value: ["x", "y", "rz"]
+    description: "specifies which joints will be used by the controller"
 
   pid:
-    rate: {
-      type: double,
-      default_value: 0.005,
+    rate:
+      type: double
+      default_value: 0.005
       description: "update loop period in seconds"
 
-    }
     __map_joints:
-      p: {
-        type: double,
-        default_value: 1.0,
-        description: "proportional gain term",
-        validation: {
-          gt_eq<>: [ 0.0001 ],
-        }
-      }
-      i: {
-        type: double,
-        default_value: 1.0,
+      p:
+        type: double
+        default_value: 1.0
+        description: "proportional gain term"
+        validation:
+          gt_eq<>: [ 0.0001 ]
+      i:
+        type: double
+        default_value: 1.0
         description: "integral gain term"
-      }
-      d: {
-        type: double,
-        default_value: 1.0,
+      d:
+        type: double
+        default_value: 1.0
         description: "derivative gain term"
-      }
 
   gains:
     __map_dof_names:
-      k: {
-        type: double,
-        default_value: 2.0,
+      k:
+        type: double
+        default_value: 2.0
         description: "general gain"
-      }
 
-  fixed_string: {
-    type: string_fixed_25,
-    default_value: "string_value",
-    description: "test code generation for fixed sized string",
-  }
-  fixed_array: {
-    type: double_array_fixed_10,
-    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3],
-    description: "test code generation for fixed sized array",
-  }
-  fixed_string_no_default: {
-    type: string_fixed_25,
-    description: "test code generation for fixed sized string with no default",
-  }
+  fixed_string:
+    type: string_fixed_25
+    default_value: "string_value"
+    description: "test code generation for fixed sized string"
+  fixed_array:
+    type: double_array_fixed_10
+    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3]
+    description: "test code generation for fixed sized array"
+  fixed_string_no_default:
+    type: string_fixed_25
+    description: "test code generation for fixed sized string with no default"
   command_interfaces:
-    {
-      type: string_array,
-      description: "specifies which command interfaces to claim",
+      type: string_array
+      description: "specifies which command interfaces to claim"
       read_only: true
-    }
 
   state_interfaces:
-    {
-      type: string_array,
-      description: "specifies which state interfaces to claim",
+      type: string_array
+      description: "specifies which state interfaces to claim"
       read_only: true
-    }
 
   chainable_command_interfaces:
-    {
-      type: string_array,
-      description: "specifies which chainable interfaces to claim",
+      type: string_array
+      description: "specifies which chainable interfaces to claim"
       read_only: true
-    }
 
   kinematics:
-    plugin_name: {
-      type: string,
+    plugin_name:
+      type: string
       description: "specifies which kinematics plugin to load"
-    }
-    plugin_package: {
-      type: string,
+    plugin_package:
+      type: string
       description: "specifies the package to load the kinematics plugin from"
-    }
-    base: {
-      type: string,
+    base:
+      type: string
       description: "specifies the base link of the robot description used by the kinematics plugin"
-    }
-    tip: {
-      type: string,
+    tip:
+      type: string
       description: "specifies the end effector link of the robot description used by the kinematics plugin"
-    }
-    alpha: {
-      type: double,
-      default_value: 0.0005,
+    alpha:
+      type: double
+      default_value: 0.0005
       description: "specifies the damping coefficient for the Jacobian pseudo inverse"
-    }
-    group_name: {
-      type: string,
+    group_name:
+      type: string
       description: "specifies the group name for planning with Moveit"
-    }
 
   ft_sensor:
-    name: {
-      type: string,
+    name:
+      type: string
       description: "name of the force torque sensor in the robot description"
-    }
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "frame of the force torque sensor"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the force torque sensor is contained in the kinematics chain from the base to the tip"
-      }
-    filter_coefficient: {
-      type: double,
-      default_value: 0.005,
+    filter_coefficient:
+      type: double
+      default_value: 0.005
       description: "specifies the coefficient for the sensor's exponential filter"
-    }
 
   control:
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "control frame used for admittance control"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the control frame is contained in the kinematics chain from the base to the tip"
-      }
 
   fixed_world_frame: # Gravity points down (neg. Z) in this frame (Usually: world or base_link)
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "world frame, gravity points down (neg. Z) in this frame"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the world frame is contained in the kinematics chain from the base to the tip"
-      }
 
   gravity_compensation:
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "frame which center of gravity (CoG) is defined in"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the center of gravity frame is contained in the kinematics chain from the base to the tip"
-      }
     CoG: # specifies the center of gravity of the end effector
-      pos: {
-        type: double_array,
-        description: "position of the center of gravity (CoG) in its frame",
-        validation: {
+      pos:
+        type: double_array
+        description: "position of the center of gravity (CoG) in its frame"
+        validation:
           fixed_size<>: 3
-        }
-      }
-      force: {
-        type: double,
-        default_value: .NAN,
+      force:
+        type: double
+        default_value: .NAN
         description: "weight of the end effector, e.g mass * 9.81"
-      }
 
   admittance:
     selected_axes:
-      {
-        type: bool_array,
-        description: "specifies if the axes x, y, z, rx, ry, and rz are enabled",
-        validation: {
+        type: bool_array
+        description: "specifies if the axes x, y, z, rx, ry, and rz are enabled"
+        validation:
           fixed_size<>: 6
-        }
-      }
 
     # Having ".0" at the end is MUST, otherwise there is a loading error
     # F = M*a + D*v + S*(x - x_d)
-    mass: {
-      type: double_array,
-      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation",
-      validation: {
-        fixed_size<>: 6,
+    mass:
+      type: double_array
+      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation"
+      validation:
+        fixed_size<>: 6
         element_bounds<>: [ 0.0001, 1000000.0 ]
-      }
-    }
 
-    damping_ratio: {
-      type: double_array,
+    damping_ratio:
+      type: double_array
       description: "specifies damping ratio values for x, y, z, rx, ry, and rz used in the admittance calculation.
-      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))",
-      validation: {
-        fixed_size<>: 6,
-        "custom_validators::validate_double_array_custom_func": [ 20.3, 5.0 ],
+      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))"
+      validation:
+        fixed_size<>: 6
+        "custom_validators::validate_double_array_custom_func": [ 20.3, 5.0 ]
         element_bounds<>: [ 0.1, 10.0 ]
-      }
-    }
 
-    stiffness: {
-      type: double_array,
-      description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation",
-      validation: {
+    stiffness:
+      type: double_array
+      description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation"
+      validation:
         element_bounds: [ 0.0001, 100000.0 ]
-      }
-    }
 
   # general settings
-  enable_parameter_update_without_reactivation: {
-    type: bool,
-    default_value: true,
+  enable_parameter_update_without_reactivation:
+    type: bool
+    default_value: true
     description: "if enabled, read_only parameters will be dynamically updated in the control loop"
-  }
-  use_feedforward_commanded_input: {
-    type: bool,
-    default_value: false,
+  use_feedforward_commanded_input:
+    type: bool
+    default_value: false
     description: "if enabled, the velocity commanded to the admittance controller is added to its calculated admittance velocity"
-  }
-  lt_eq_fifteen: {
-    type: int,
-    default_value: 1,
-    description: "should be a number less than or equal to 15",
-    validation: {
-      lt_eq<>: [ 15 ],
-    }
-  }
-  gt_fifteen: {
-    type: int,
-    default_value: 16,
-    description: "should be a number greater than 15",
-    validation: {
-      gt<>: [ 15 ],
-    }
-  }
-  one_number: {
-    type: int,
-    default_value: 14540,
-    read_only: true,
-    validation: {
+  lt_eq_fifteen:
+    type: int
+    default_value: 1
+    description: "should be a number less than or equal to 15"
+    validation:
+      lt_eq<>: [ 15 ]
+  gt_fifteen:
+    type: int
+    default_value: 16
+    description: "should be a number greater than 15"
+    validation:
+      gt<>: [ 15 ]
+  one_number:
+    type: int
+    default_value: 14540
+    read_only: true
+    validation:
       bounds<>: [ 1024, 65535 ]
-    }
-  }
-  three_numbers: {
-    type: int_array,
-    default_value: [3,4,5],
-    read_only: true,
-  }
-  three_numbers_of_five: {
-    type: int_array_fixed_5,
-    default_value: [3,3,3],
-    read_only: true,
-  }
+  three_numbers:
+    type: int_array
+    default_value: [3,4,5]
+    read_only: true
+  three_numbers_of_five:
+    type: int_array_fixed_5
+    default_value: [3,3,3]
+    read_only: true

--- a/example_python/generate_parameter_module_example/parameters.yaml
+++ b/example_python/generate_parameter_module_example/parameters.yaml
@@ -1,341 +1,271 @@
 admittance_controller:
-  scientific_notation_num: {
-    type: double,
-    default_value: 0.00000000001,
-    description: "Test scientific notation",
-  }
-  interpolation_mode: {
-    type: string,
-    default_value: "spline",
-    description: "specifies which algorithm to use for interpolation.",
-    validation: {
-      one_of<>: [ [ "spline", "linear" ] ],
+  scientific_notation_num:
+    type: double
+    default_value: 0.00000000001
+    description: "Test scientific notation"
+  interpolation_mode:
+    type: string
+    default_value: "spline"
+    description: "specifies which algorithm to use for interpolation."
+    validation:
+      one_of<>: [ [ "spline", "linear" ] ]
       "custom_validators::no_args_validator": null
-    }
-  }
-  subset_selection: {
-    type: string_array,
-    default_value: ["A", "B"],
-    description: "test subset of validator.",
-    validation: {
-      subset_of<>: [ [ "A", "B", "C"] ],
-      }
-  }
-  joints: {
-    type: string_array,
-    default_value: ["joint1", "joint2", "joint3"],
-    description: "specifies which joints will be used by the controller",
-  }
-  dof_names: {
-    type: string_array,
-    default_value: ["x", "y", "rz"],
-    description: "specifies which joints will be used by the controller",
-  }
+  subset_selection:
+    type: string_array
+    default_value: ["A", "B"]
+    description: "test subset of validator."
+    validation:
+      subset_of<>: [ [ "A", "B", "C"] ]
+  joints:
+    type: string_array
+    default_value: ["joint1", "joint2", "joint3"]
+    description: "specifies which joints will be used by the controller"
+  dof_names:
+    type: string_array
+    default_value: ["x", "y", "rz"]
+    description: "specifies which joints will be used by the controller"
 
   __map_joints:
     __map_dof_names:
-      weight: {
-        type: double,
-        default_value: 1.0,
-        description: "map parameter without struct name",
-        validation: {
-          gt<>: [0.0],
-        }
-      }
+      weight:
+        type: double
+        default_value: 1.0
+        description: "map parameter without struct name"
+        validation:
+          gt<>: [0.0]
 
   nested_dynamic:
     __map_joints:
       __map_dof_names:
-        nested: {
-          type: double,
-          default_value: 1.0,
-          description: "test nested map params",
-          validation: {
-            gt_eq<>: [ 0.0001 ],
-          }
-        }
+        nested:
+          type: double
+          default_value: 1.0
+          description: "test nested map params"
+          validation:
+            gt_eq<>: [ 0.0001 ]
         __map_joints:
           __map_dof_names:
-            nested_deep: {
-              type: double,
-              default_value: 1.0,
-              description: "test deep nested map params",
-              validation: {
-                gt_eq<>: [ 0.0001 ],
-              }
-            }
+            nested_deep:
+              type: double
+              default_value: 1.0
+              description: "test deep nested map params"
+              validation:
+                gt_eq<>: [ 0.0001 ]
   pid:
-    rate: {
-      type: double,
-      default_value: 0.005,
+    rate:
+      type: double
+      default_value: 0.005
       description: "update loop period in seconds"
-
-    }
     __map_joints:
-      p: {
-        type: double,
-        default_value: 1.0,
-        description: "proportional gain term",
-        validation: {
-          gt_eq<>: [ 0.0001 ],
-        }
-      }
-      i: {
-        type: double,
-        default_value: 1.0,
+      p:
+        type: double
+        default_value: 1.0
+        description: "proportional gain term"
+        validation:
+          gt_eq<>: [ 0.0001 ]
+      i:
+        type: double
+        default_value: 1.0
         description: "integral gain term"
-      }
-      d: {
-        type: double,
-        default_value: 1.0,
+      d:
+        type: double
+        default_value: 1.0
         description: "derivative gain term"
-      }
 
   gains:
     __map_dof_names:
-      k: {
-        type: double,
-        default_value: 2.0,
+      k:
+        type: double
+        default_value: 2.0
         description: "general gain"
-      }
 
-  fixed_string: {
-    type: string_fixed_25,
-    default_value: "string_value",
-    description: "test code generation for fixed sized string",
-  }
-  fixed_array: {
-    type: double_array_fixed_10,
-    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3],
-    description: "test code generation for fixed sized array",
-  }
-  fixed_string_no_default: {
-    type: string_fixed_25,
-    description: "test code generation for fixed sized string with no default",
-  }
+  fixed_string:
+    type: string_fixed_25
+    default_value: "string_value"
+    description: "test code generation for fixed sized string"
+  fixed_array:
+    type: double_array_fixed_10
+    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3]
+    description: "test code generation for fixed sized array"
+  fixed_string_no_default:
+    type: string_fixed_25
+    description: "test code generation for fixed sized string with no default"
   command_interfaces:
-    {
-      type: string_array,
-      description: "specifies which command interfaces to claim",
+      type: string_array
+      description: "specifies which command interfaces to claim"
       read_only: true
-    }
 
   state_interfaces:
-    {
-      type: string_array,
-      description: "specifies which state interfaces to claim",
+      type: string_array
+      description: "specifies which state interfaces to claim"
       read_only: true
-    }
 
   chainable_command_interfaces:
-    {
-      type: string_array,
-      description: "specifies which chainable interfaces to claim",
+      type: string_array
+      description: "specifies which chainable interfaces to claim"
       read_only: true
-    }
 
   kinematics:
-    plugin_name: {
-      type: string,
+    plugin_name:
+      type: string
       description: "specifies which kinematics plugin to load"
-    }
-    plugin_package: {
-      type: string,
+    plugin_package:
+      type: string
       description: "specifies the package to load the kinematics plugin from"
-    }
-    base: {
-      type: string,
+    base:
+      type: string
       description: "specifies the base link of the robot description used by the kinematics plugin"
-    }
-    tip: {
-      type: string,
+    tip:
+      type: string
       description: "specifies the end effector link of the robot description used by the kinematics plugin"
-    }
-    alpha: {
-      type: double,
-      default_value: 0.0005,
+    alpha:
+      type: double
+      default_value: 0.0005
       description: "specifies the damping coefficient for the Jacobian pseudo inverse"
-    }
-    group_name: {
-      type: string,
+    group_name:
+      type: string
       description: "specifies the group name for planning with Moveit"
-    }
 
   ft_sensor:
-    name: {
-      type: string,
+    name:
+      type: string
       description: "name of the force torque sensor in the robot description"
-    }
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "frame of the force torque sensor"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the force torque sensor is contained in the kinematics chain from the base to the tip"
-      }
-    filter_coefficient: {
-      type: double,
-      default_value: 0.005,
+    filter_coefficient:
+      type: double
+      default_value: 0.005
       description: "specifies the coefficient for the sensor's exponential filter"
-    }
 
   control:
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "control frame used for admittance control"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the control frame is contained in the kinematics chain from the base to the tip"
-      }
 
   fixed_world_frame: # Gravity points down (neg. Z) in this frame (Usually: world or base_link)
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "world frame, gravity points down (neg. Z) in this frame"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the world frame is contained in the kinematics chain from the base to the tip"
-      }
 
   gravity_compensation:
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "frame which center of gravity (CoG) is defined in"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the center of gravity frame is contained in the kinematics chain from the base to the tip"
-      }
     CoG: # specifies the center of gravity of the end effector
-      pos: {
-        type: double_array,
-        description: "position of the center of gravity (CoG) in its frame",
-        validation: {
+      pos:
+        type: double_array
+        description: "position of the center of gravity (CoG) in its frame"
+        validation:
           fixed_size<>: 3
-        }
-      }
-      force: {
-        type: double,
-        default_value: .NAN,
+      force:
+        type: double
+        default_value: .NAN
         description: "weight of the end effector, e.g mass * 9.81"
-      }
 
   admittance:
     selected_axes:
-      {
-        type: bool_array,
-        description: "specifies if the axes x, y, z, rx, ry, and rz are enabled",
-        validation: {
+        type: bool_array
+        description: "specifies if the axes x, y, z, rx, ry, and rz are enabled"
+        validation:
           fixed_size<>: 6
-        }
-      }
 
     # Having ".0" at the end is MUST, otherwise there is a loading error
     # F = M*a + D*v + S*(x - x_d)
-    mass: {
-      type: double_array,
-      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation",
-      validation: {
-        fixed_size<>: 6,
+    mass:
+      type: double_array
+      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation"
+      validation:
+        fixed_size<>: 6
         element_bounds<>: [ 0.0001, 1000000.0 ]
-      }
-    }
 
-    damping_ratio: {
-      type: double_array,
+    damping_ratio:
+      type: double_array
       description: "specifies damping ratio values for x, y, z, rx, ry, and rz used in the admittance calculation.
-      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))",
-      validation: {
-        fixed_size<>: 6,
-        "custom_validators::validate_double_array_custom_func": [ 20.3, 5.0 ],
+      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))"
+      validation:
+        fixed_size<>: 6
+        "custom_validators::validate_double_array_custom_func": [ 20.3, 5.0 ]
         element_bounds<>: [ 0.1, 10.0 ]
-      }
-    }
 
-    stiffness: {
-      type: double_array,
-      description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation",
-      validation: {
+    stiffness:
+      type: double_array
+      description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation"
+      validation:
         element_bounds: [ 0.0001, 100000.0 ]
-      }
-    }
 
   # general settings
-  enable_parameter_update_without_reactivation: {
-    type: bool,
-    default_value: true,
+  enable_parameter_update_without_reactivation:
+    type: bool
+    default_value: true
     description: "if enabled, read_only parameters will be dynamically updated in the control loop"
-  }
-  use_feedforward_commanded_input: {
-    type: bool,
-    default_value: false,
+  use_feedforward_commanded_input:
+    type: bool
+    default_value: false
     description: "if enabled, the velocity commanded to the admittance controller is added to its calculated admittance velocity"
-  }
-  lt_eq_fifteen: {
-    type: int,
-    default_value: 1,
-    description: "should be a number less than or equal to 15",
-    validation: {
-      lt_eq<>: [ 15 ],
-    }
-  }
-  gt_fifteen: {
-    type: int,
-    default_value: 16,
-    description: "should be a number greater than 15",
-    validation: {
-      gt<>: [ 15 ],
-    }
-  }
-  one_number: {
-    type: int,
-    default_value: 14540,
-    read_only: true,
-    validation: {
+  lt_eq_fifteen:
+    type: int
+    default_value: 1
+    description: "should be a number less than or equal to 15"
+    validation:
+      lt_eq<>: [ 15 ]
+  gt_fifteen:
+    type: int
+    default_value: 16
+    description: "should be a number greater than 15"
+    validation:
+      gt<>: [ 15 ]
+  one_number:
+    type: int
+    default_value: 14540
+    read_only: true
+    validation:
       bounds<>: [ 1024, 65535 ]
-    }
-  }
-  three_numbers: {
-    type: int_array,
-    default_value: [3,4,5],
-    read_only: true,
-  }
-  three_numbers_of_five: {
-    type: int_array_fixed_5,
-    default_value: [3,3,3],
-    read_only: true,
-  }
-  hover_override: {
-    type: int,
-    default_value: 1,
-    description: "Override hover action:\n0: Hover\n1: Push\n2: Pull\n-1: Do not override",
-    validation: {
-      one_of<>: [ [ 0, 1, 2, -1 ] ],
-    },
-  }
-  angle_wraparound: {
-    type: bool,
-    default_value: false,
-    description: 'For joints that wrap around (without end stop, ie. are continuous),
+  three_numbers:
+    type: int_array
+    default_value: [3,4,5]
+    read_only: true
+  three_numbers_of_five:
+    type: int_array_fixed_5
+    default_value: [3,3,3]
+    read_only: true
+  hover_override:
+    type: int
+    default_value: 1
+    description: "Override hover action:\n0: Hover\n1: Push\n2: Pull\n-1: Do not override"
+    validation:
+      one_of<>: [ [ 0, 1, 2, -1 ] ]
+  angle_wraparound:
+    type: bool
+    default_value: false
+    description: 'For joints that wrap around (without end stop, ie. are continuous)
           where the shortest rotation to the target position is the desired motion.
           If true, the position error :math:`e = normalize(s_d - s)` is normalized between :math:`-\pi, \pi`.
           Otherwise  :math:`e = s_d - s` is used, with the desired position :math:`s_d` and the measured
           position :math:`s` from the state interface.'
-  }
-  open_loop_control: {
-    type: bool,
-    default_value: false,
+  open_loop_control:
+    type: bool
+    default_value: false
     description: "Use controller in open-loop control mode
         \n\n
         * The controller ignores the states provided by hardware interface but using last commands as states for starting the trajectory interpolation.\n
@@ -345,6 +275,5 @@ admittance_controller:
         \n\n
         If this flag is set, the controller tries to read the values from the command interfaces on activation.
         If they have real numeric values, those will be used instead of state interfaces.
-        Therefore it is important set command interfaces to NaN (i.e., ``std::numeric_limits<double>::quiet_NaN()``) or state values when the hardware is started.\n",
-    read_only: true,
-  }
+        Therefore it is important set command interfaces to NaN (i.e., ``std::numeric_limits<double>::quiet_NaN()``) or state values when the hardware is started.\n"
+    read_only: true

--- a/generate_parameter_library_py/generate_parameter_library_py/test/invalid_syntax.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/invalid_syntax.yaml
@@ -1,8 +1,7 @@
 namespace:
-  param_name: {
-    type: double,
-    description: "Test scientific notation",
-  }
+  param_name:
+    type: double
+    description: "Test scientific notation"
   -
     -
       -

--- a/generate_parameter_library_py/generate_parameter_library_py/test/missing_type.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/missing_type.yaml
@@ -1,4 +1,3 @@
 namespace:
-  param_name: {
-    description: "Test scientific notation",
-  }
+  param_name:
+    description: "Test scientific notation"

--- a/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
@@ -1,228 +1,180 @@
 admittance_controller:
-  scientific_notation_num: {
-    type: double,
-    default_value: 0.00000000001,
-    description: "Test scientific notation",
-  }
-  interpolation_mode: {
-    type: string,
-    default_value: "spline",
-    description: "specifies which algorithm to use for interpolation.",
-    validation: {
-      one_of<>: [ [ "spline", "linear" ] ],
+  scientific_notation_num:
+    type: double
+    default_value: 0.00000000001
+    description: "Test scientific notation"
+  interpolation_mode:
+    type: string
+    default_value: "spline"
+    description: "specifies which algorithm to use for interpolation."
+    validation:
+      one_of<>: [ [ "spline", "linear" ] ]
       no_args_validator: null
-    }
-  }
-  joints: {
-    type: string_array,
-    default_value: ["joint1", "joint2", "joint3"],
-    description: "specifies which joints will be used by the controller",
-  }
+  joints:
+    type: string_array
+    default_value: ["joint1", "joint2", "joint3"]
+    description: "specifies which joints will be used by the controller"
   pid:
-    rate: {
-      type: double,
-      default_value: 0.005,
+    rate:
+      type: double
+      default_value: 0.005
       description: "update loop period in seconds"
 
-    }
     __map_joints:
-      p: {
-        type: double,
-        default_value: 1.0,
-        description: "proportional gain term",
-        validation: {
-          gt_eq<>: [ 0 ],
-        }
-      }
-      i: {
-        type: double,
+      p:
+        type: double
+        default_value: 1.0
+        description: "proportional gain term"
+        validation:
+          gt_eq<>: [ 0 ]
+      i:
+        type: double
         description: "integral gain term"
-      }
-      d: {
-        type: double,
-        default_value: 1.0,
+      d:
+        type: double
+        default_value: 1.0
         description: "derivative gain term"
-      }
-  fixed_string: {
-    type: string_fixed_25,
-    default_value: "string_value",
-    description: "test code generation for fixed sized string",
-  }
-  fixed_array: {
-    type: double_array_fixed_10,
-    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3],
-    description: "test code generation for fixed sized array",
-  }
-  fixed_string_no_default: {
-    type: string_fixed_25,
-    description: "test code generation for fixed sized string with no default",
-  }
+  fixed_string:
+    type: string_fixed_25
+    default_value: "string_value"
+    description: "test code generation for fixed sized string"
+  fixed_array:
+    type: double_array_fixed_10
+    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3]
+    description: "test code generation for fixed sized array"
+  fixed_string_no_default:
+    type: string_fixed_25
+    description: "test code generation for fixed sized string with no default"
   command_interfaces:
-    {
-      type: string_array,
-      description: "specifies which command interfaces to claim",
+      type: string_array
+      description: "specifies which command interfaces to claim"
       read_only: true
-    }
 
   state_interfaces:
-    {
-      type: string_array,
-      description: "specifies which state interfaces to claim",
+      type: string_array
+      description: "specifies which state interfaces to claim"
       read_only: true
-    }
 
   chainable_command_interfaces:
-    {
-      type: string_array,
-      description: "specifies which chainable interfaces to claim",
+      type: string_array
+      description: "specifies which chainable interfaces to claim"
       read_only: true
-    }
 
   kinematics:
-    plugin_name: {
-      type: string,
+    plugin_name:
+      type: string
       description: "specifies which kinematics plugin to load"
-    }
-    plugin_package: {
-      type: string,
+    plugin_package:
+      type: string
       description: "specifies the package to load the kinematics plugin from"
-    }
-    base: {
-      type: string,
+    base:
+      type: string
       description: "specifies the base link of the robot description used by the kinematics plugin"
-    }
-    tip: {
-      type: string,
+    tip:
+      type: string
       description: "specifies the end effector link of the robot description used by the kinematics plugin"
-    }
-    alpha: {
-      type: double,
-      default_value: 0.0005,
+    alpha:
+      type: double
+      default_value: 0.0005
       description: "specifies the damping coefficient for the Jacobian pseudo inverse"
-    }
-    group_name: {
-      type: string,
+    group_name:
+      type: string
       description: "specifies the group name for planning with Moveit"
-    }
 
   ft_sensor:
-    name: {
-      type: string,
+    name:
+      type: string
       description: "name of the force torque sensor in the robot description"
-    }
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "frame of the force torque sensor"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the force torque sensor is contained in the kinematics chain from the base to the tip"
-      }
-    filter_coefficient: {
-      type: double,
-      default_value: 0.005,
+    filter_coefficient:
+      type: double
+      default_value: 0.005
       description: "specifies the coefficient for the sensor's exponential filter"
-    }
 
   control:
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "control frame used for admittance control"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the control frame is contained in the kinematics chain from the base to the tip"
-      }
 
   fixed_world_frame: # Gravity points down (neg. Z) in this frame (Usually: world or base_link)
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "world frame, gravity points down (neg. Z) in this frame"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the world frame is contained in the kinematics chain from the base to the tip"
-      }
 
   gravity_compensation:
     frame:
-      id: {
-        type: string,
+      id:
+        type: string
         description: "frame which center of gravity (CoG) is defined in"
-      }
-      external: {
-        type: bool,
-        default_value: false,
+      external:
+        type: bool
+        default_value: false
         description: "specifies if the center of gravity frame is contained in the kinematics chain from the base to the tip"
-      }
     CoG: # specifies the center of gravity of the end effector
-      pos: {
-        type: double_array,
-        description: "position of the center of gravity (CoG) in its frame",
-        validation: {
+      pos:
+        type: double_array
+        description: "position of the center of gravity (CoG) in its frame"
+        validation:
           fixed_size<>: 3
-        }
-      }
-      force: {
-        type: double,
-        default_value: .NAN,
+      force:
+        type: double
+        default_value: .NAN
         description: "weight of the end effector, e.g mass * 9.81"
-      }
 
   admittance:
     selected_axes:
-      {
-        type: bool_array,
-        description: "specifies if the axes x, y, z, rx, ry, and rz are enabled",
-        validation: {
+        type: bool_array
+        description: "specifies if the axes x, y, z, rx, ry, and rz are enabled"
+        validation:
           fixed_size<>: 6
-        }
-      }
 
     # Having ".0" at the end is MUST, otherwise there is a loading error
     # F = M*a + D*v + S*(x - x_d)
-    mass: {
-      type: double_array,
-      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation",
-      validation: {
-        fixed_size<>: 6,
+    mass:
+      type: double_array
+      description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation"
+      validation:
+        fixed_size<>: 6
         element_bounds<>: [ 0.0001, 1000000.0 ]
-      }
-    }
 
-    damping_ratio: {
-      type: double_array,
+    damping_ratio:
+      type: double_array
       description: "specifies damping ratio values for x, y, z, rx, ry, and rz used in the admittance calculation.
-      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))",
-      validation: {
-        fixed_size<>: 6,
-        validate_double_array_custom_func: [ 20.3, 5.0 ],
+      The values are calculated as damping can be used instead: zeta = D / (2 * sqrt( M * S ))"
+      validation:
+        fixed_size<>: 6
+        validate_double_array_custom_func: [ 20.3, 5.0 ]
         element_bounds<>: [ 0.1, 10.0 ]
-      }
-    }
 
-    stiffness: {
-      type: double_array,
-      description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation",
-      validation: {
+    stiffness:
+      type: double_array
+      description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation"
+      validation:
         element_bounds: [ 0.0001, 100000.0 ]
-      }
-    }
 
   # general settings
-  enable_parameter_update_without_reactivation: {
-    type: bool,
-    default_value: true,
+  enable_parameter_update_without_reactivation:
+    type: bool
+    default_value: true
     description: "if enabled, read_only parameters will be dynamically updated in the control loop"
-  }
-  use_feedforward_commanded_input: {
-    type: bool,
-    default_value: false,
+  use_feedforward_commanded_input:
+    type: bool
+    default_value: false
     description: "if enabled, the velocity commanded to the admittance controller is added to its calculated admittance velocity"
-  }

--- a/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters_with_none_type.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters_with_none_type.yaml
@@ -1,11 +1,9 @@
 some_controller:
-  some_parameter: {
-    type: string,
-    default_value: "default",
-    description: "Test parameter that should generate code.",
-  }
+  some_parameter:
+    type: string
+    default_value: "default"
+    description: "Test parameter that should generate code."
 
-  some_external_parameter: {
-    type: none,
-    description: "Parameter that should not generate any code but must be accepted.",
-  }
+  some_external_parameter:
+    type: none
+    description: "Parameter that should not generate any code but must be accepted."

--- a/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/validation_only_parameters.yaml
@@ -1,94 +1,73 @@
 admittance_controller:
-  stiffness: {
-    type: double_array,
-    description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation",
-    validation: {
+  stiffness:
+    type: double_array
+    description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation"
+    validation:
       element_bounds: [ 0.0001, 100000.0 ]
-    }
-  }
-  dankness: {
-    type: int_array,
-    description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation",
-    validation: {
+  dankness:
+    type: int_array
+    description: "specifies stiffness values for x, y, z, rx, ry, and rz used in the admittance calculation"
+    validation:
       element_bounds: [ 1, 100 ]
-    }
-  }
 
-  mass: {
-    type: double_array,
-    description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation",
-    validation: {
-      fixed_size<>: 6,
+  mass:
+    type: double_array
+    description: "specifies mass values for x, y, z, rx, ry, and rz used in the admittance calculation"
+    validation:
+      fixed_size<>: 6
       element_bounds<>: [ 0.0001, 1000000.0 ]
-    }
-  }
 
-  one_number: {
-    type: int,
-    default_value: 14540,
-    read_only: true,
-    validation: {
+  one_number:
+    type: int
+    default_value: 14540
+    read_only: true
+    validation:
       bounds<>: [ 1024, 65535 ]
-    }
-  }
 
-  p: {
-    type: double,
-    default_value: 1.0,
-    description: "proportional gain term",
-    validation: {
-      gt_eq<>: [ 0 ],
-    }
-  }
+  p:
+    type: double
+    default_value: 1.0
+    description: "proportional gain term"
+    validation:
+      gt_eq<>: [ 0 ]
 
-  p2: {
-    type: double,
-    default_value: 1.0,
-    description: "proportional gain term updated",
-    validation: {
-      gt_eq: [ 0.0001 ],
-    }
-  }
+  p2:
+    type: double
+    default_value: 1.0
+    description: "proportional gain term updated"
+    validation:
+      gt_eq: [ 0.0001 ]
 
-  under_ten: {
-    type: double,
-    default_value: 1.0,
-    description: "should be a number less than 10",
-    validation: {
-      lt_eq<>: [ 10 ],
-    }
-  }
-  lt_eq_fifteen: {
-    type: int,
-    default_value: 1,
-    description: "should be a number less than or equal to 15",
-    validation: {
-      lt_eq<>: [ 15 ],
-    }
-  }
-  gt_fifteen: {
-    type: int,
-    default_value: 16,
-    description: "should be a number greater than 15",
-    validation: {
-      gt<>: [ 15 ],
-    }
-  }
+  under_ten:
+    type: double
+    default_value: 1.0
+    description: "should be a number less than 10"
+    validation:
+      lt_eq<>: [ 10 ]
+  lt_eq_fifteen:
+    type: int
+    default_value: 1
+    description: "should be a number less than or equal to 15"
+    validation:
+      lt_eq<>: [ 15 ]
+  gt_fifteen:
+    type: int
+    default_value: 16
+    description: "should be a number greater than 15"
+    validation:
+      gt<>: [ 15 ]
   # This shouldn't populate any description range constraints
-  fixed_array: {
-    type: double_array_fixed_10,
-    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3],
-    description: "test code generation for fixed sized array",
-  }
+  fixed_array:
+    type: double_array_fixed_10
+    default_value: [1.0, 2.3, 4.0 ,5.4, 3.3]
+    description: "test code generation for fixed sized array"
 
     # general settings
-  enable_parameter_update_without_reactivation: {
-    type: bool,
-    default_value: true,
+  enable_parameter_update_without_reactivation:
+    type: bool
+    default_value: true
     description: "if enabled, read_only parameters will be dynamically updated in the control loop"
-  }
-  use_feedforward_commanded_input: {
-    type: bool,
-    default_value: false,
+  use_feedforward_commanded_input:
+    type: bool
+    default_value: false
     description: "if enabled, the velocity commanded to the admittance controller is added to its calculated admittance velocity"
-  }

--- a/generate_parameter_library_py/generate_parameter_library_py/test/wrong_default_type.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/wrong_default_type.yaml
@@ -1,6 +1,5 @@
 namespace:
-  param_name: {
-    type: double,
-    default_value: "string type",
-    description: "Test scientific notation",
-  }
+  param_name:
+    type: double
+    default_value: "string type"
+    description: "Test scientific notation"


### PR DESCRIPTION
I noticed in some reviews internally that the brackets were used inconsistently. Turns out they were mostly copy pasted from the great parameter library.

May I suggest dropping the bracket syntax? It's yaml after-all, not json :slightly_smiling_face: 

As you can already see in the first README example, it was a bit inconsistent, they are not used after `turtlesim` but are used after `background`.