### PR TITLE
Add Non-Blocking try_get_params Function for Real-Time Control Systems

### DIFF
--- a/example/test/example_test_gtest.cpp
+++ b/example/test/example_test_gtest.cpp
@@ -40,10 +40,9 @@ class ExampleTest : public ::testing::Test {
   void SetUp() {
     example_test_node_ = std::make_shared<rclcpp::Node>("example_test_node");
 
-    std::shared_ptr<admittance_controller::ParamListener> param_listener =
-        std::make_shared<admittance_controller::ParamListener>(
-            example_test_node_->get_node_parameters_interface());
-    params_ = param_listener->get_params();
+    param_listener_ = std::make_shared<admittance_controller::ParamListener>(
+        example_test_node_->get_node_parameters_interface());
+    params_ = param_listener_->get_params();
   }
 
   void TearDown() { example_test_node_.reset(); }
@@ -51,6 +50,7 @@ class ExampleTest : public ::testing::Test {
  protected:
   std::shared_ptr<rclcpp::Node> example_test_node_;
   admittance_controller::Params params_;
+  std::shared_ptr<admittance_controller::ParamListener> param_listener_;
 };
 
 TEST_F(ExampleTest, check_parameters) {
@@ -62,6 +62,15 @@ TEST_F(ExampleTest, check_parameters) {
   EXPECT_EQ(params_.joints[2], "joint6");
 
   ASSERT_EQ(params_.ft_sensor.filter_coefficient, 0.1);
+}
+
+TEST_F(ExampleTest, try_get_params) {
+  ASSERT_TRUE(param_listener_->try_get_params(params_));
+
+  const rclcpp ::Parameter new_param("interpolation_mode", "linear");
+  example_test_node_->set_parameter(new_param);
+  ASSERT_TRUE(param_listener_->try_get_params(params_));
+  ASSERT_EQ(params_.interpolation_mode, "linear");
 }
 
 int main(int argc, char** argv) {

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -123,6 +123,17 @@ struct StackParams {
       return params_;
     }
 
+    bool try_get_params(Params & params_in) const{
+      if (mutex_.try_lock()) {
+        if (const bool is_old = params_in.__stamp != params_.__stamp; is_old) {
+          params_in = params_;
+        }
+        mutex_.unlock();
+        return true;
+      }
+      return false;
+    }
+
     bool is_old(Params const& other) const {
       std::lock_guard<std::mutex> lock(mutex_);
       return params_.__stamp != other.__stamp;

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -123,7 +123,7 @@ struct StackParams {
       return params_;
     }
 
-    bool try_get_params(Params & params_in) const{
+    bool try_get_params(Params & params_in) const {
       if (mutex_.try_lock()) {
         if (const bool is_old = params_in.__stamp != params_.__stamp; is_old) {
           params_in = params_;


### PR DESCRIPTION
This pull request adds a new function, `try_get_params()`, to improve responsiveness especially in real-time systems by avoiding blocking operations. The existing `is_old()` function also risks blocking, so I incorporated it into `try_get_params()`.