### PR TITLE
Fix python lib install path

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
@@ -55,7 +55,6 @@ def generate_parameter_module(module_name, yaml_file, validation_module=''):
             install_dir = os.path.join(
                 colcon_ws,
                 'install',
-                pkg_name,
                 'lib',
                 py_version,
                 'site-packages',


### PR DESCRIPTION
The Python library install path is incorrect and writes the generated files to an incorrect location.

The path has an additional `pkg_name` folder in the target directory.

Tested on Humble (Ubuntu 22)