### PR TITLE
Fix nested parameter update

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/update_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/update_runtime_parameter
@@ -5,9 +5,9 @@ for value_{{loop.index}} in updated_params.{{mapped_param}}:
 {% endfor -%}
 {%- filter indent(width=4*(1+mapped_params|length)) %}
 {% if struct_name != "" %}
-param_name = f"{self.prefix_}{{struct_name}}{% for map in parameter_map%}{value_{{loop.index}}}.{% endfor %}{{parameter_field}}"
+param_name = f"{self.prefix_}{{struct_name}}{% for map in parameter_map%}.{value_{{loop.index}}}.{% endfor %}{{parameter_field}}"
 {% else %}
-param_name = f"{self.prefix_}{% for map in parameter_map%}{value_{{loop.index}}}.{% endfor %}{{parameter_field}}"
+param_name = f"{self.prefix_}{% for map in parameter_map%}.{value_{{loop.index}}}.{% endfor %}{{parameter_field}}"
 {% endif -%}
 if param.name == param_name:
 {%- filter indent(width=4) %}


### PR DESCRIPTION
When calling `param_listener.update(override_parameters)` nested parameters will fail to load because of the missing namespace separator `.`

This PR fixes the template that creates update() function for the parameters with mapped namespaces so that they match & update properly.