### PR TITLE
Add ability for param_listener to load values from yaml dictionary

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
@@ -29,7 +29,7 @@ def unpack_parameter_dict(namespace: str, parameter_dict: dict):
     for param_name, param_value in parameter_dict.items():
         full_param_name = namespace + param_name
         # Unroll nested parameters
-        if type(param_value) == dict:
+        if isinstance(param_value, dict):
             nested_params = unpack_parameter_dict(
                     namespace=full_param_name + '.',
                     parameter_dict=param_value)
@@ -51,6 +51,7 @@ stamp_ = Time()
 {{sub_struct_content-}}
 {% endfilter -%}
 {%- endfilter %}
+
 
     class ParamListener:
         def __init__(self, node, prefix=""):

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
@@ -15,29 +15,7 @@ from generate_parameter_library_py.python_validators import ParameterValidators
 
 {% if user_validation_file|length -%}
 import {{user_validation_file}} as custom_validators
-{% endif -%}
-
-def unpack_parameter_dict(namespace: str, parameter_dict: dict):
-    """
-    Flatten a parameter dictionary recursively.
-
-    :param namespace: The namespace to prepend to the parameter names.
-    :param parameter_dict: A dictionary of parameters keyed by the parameter names
-    :return: A list of rclpy Parameter objects
-    """
-    parameters = []
-    for param_name, param_value in parameter_dict.items():
-        full_param_name = namespace + param_name
-        # Unroll nested parameters
-        if isinstance(param_value, dict):
-            nested_params = unpack_parameter_dict(
-                    namespace=full_param_name + rclpy.parameter.PARAMETER_SEPARATOR_STRING,
-                    parameter_dict=param_value)
-            parameters.extend(nested_params)
-        else:
-            parameters.append(rclpy.parameter.Parameter(full_param_name, value=param_value))
-    return parameters
-
+{% endif %}
 
 class {{namespace}}:
 {%- filter indent(width=4) %}
@@ -75,6 +53,28 @@ stamp_ = Time()
 
         def is_old(self, other_param):
             return self.params_.stamp_ != other_param.stamp_
+
+        @staticmethod
+        def unpack_parameter_dict(namespace: str, parameter_dict: dict):
+            """
+            Flatten a parameter dictionary recursively.
+
+            :param namespace: The namespace to prepend to the parameter names.
+            :param parameter_dict: A dictionary of parameters keyed by the parameter names
+            :return: A list of rclpy Parameter objects
+            """
+            parameters = []
+            for param_name, param_value in parameter_dict.items():
+                full_param_name = namespace + param_name
+                # Unroll nested parameters
+                if isinstance(param_value, dict):
+                    nested_params = unpack_parameter_dict(
+                            namespace=full_param_name + rclpy.parameter.PARAMETER_SEPARATOR_STRING,
+                            parameter_dict=param_value)
+                    parameters.extend(nested_params)
+                else:
+                    parameters.append(rclpy.parameter.Parameter(full_param_name, value=param_value))
+            return parameters
 
         def set_params_from_dict(self, param_dict):
             params_to_set = unpack_parameter_dict('', param_dict)

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
@@ -10,11 +10,34 @@ from rclpy.exceptions import InvalidParameterValueException
 from rclpy.time import Time
 import copy
 import rclpy
+import rclpy.parameter
 from generate_parameter_library_py.python_validators import ParameterValidators
 
 {% if user_validation_file|length -%}
 import {{user_validation_file}} as custom_validators
-{% endif %}
+{% endif -%}
+
+def unpack_parameter_dict(namespace: str, parameter_dict: dict):
+    """
+    Flatten a parameter dictionary recursively.
+
+    :param namespace: The namespace to prepend to the parameter names.
+    :param parameter_dict: A dictionary of parameters keyed by the parameter names
+    :return: A list of rclpy Parameter objects
+    """
+    parameters = []
+    for param_name, param_value in parameter_dict.items():
+        full_param_name = namespace + param_name
+        # Unroll nested parameters
+        if type(param_value) == dict:
+            nested_params = unpack_parameter_dict(
+                    namespace=full_param_name + '.',
+                    parameter_dict=param_value)
+            parameters.extend(nested_params)
+        else:
+            parameters.append(rclpy.parameter.Parameter(full_param_name, value=param_value))
+    return parameters
+
 
 class {{namespace}}:
 {%- filter indent(width=4) %}
@@ -28,7 +51,6 @@ stamp_ = Time()
 {{sub_struct_content-}}
 {% endfilter -%}
 {%- endfilter %}
-
 
     class ParamListener:
         def __init__(self, node, prefix=""):
@@ -52,6 +74,10 @@ stamp_ = Time()
 
         def is_old(self, other_param):
             return self.params_.stamp_ != other_param.stamp_
+
+        def set_params_from_dict(self, param_dict):
+            params_to_set = unpack_parameter_dict('', param_dict)
+            self.update(params_to_set)
 
         def refresh_dynamic_parameters(self):
             updated_params = self.get_params()

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
@@ -31,7 +31,7 @@ def unpack_parameter_dict(namespace: str, parameter_dict: dict):
         # Unroll nested parameters
         if isinstance(param_value, dict):
             nested_params = unpack_parameter_dict(
-                    namespace=full_param_name + '.',
+                    namespace=full_param_name + rclpy.parameter.PARAMETER_SEPARATOR_STRING,
                     parameter_dict=param_value)
             parameters.extend(nested_params)
         else:


### PR DESCRIPTION
This PR makes it so the `parameter_listener` can refresh it's copy of parameters with ones specified in a yaml dictionary and would close #208.

To load and the get the parameters
```python
        self.param_listener = my_param_namespace.ParamListener(self.node)
        path_to_config = os.path.dirname(__file__) + '/config/my_config_file.yaml'
        with open(path_to_config) as file:
            configParamsFromYaml = yaml.safe_load(file)['my_param_namespace']['ros__parameters']

        self.param_listener.set_params_from_dict(configParamsFromYaml)
        self.test_params = self.param_listener.get_params()
```