### PR TITLE
Fix a typo preventing to use the full int64_t range when using gt<> and lt<> validators

### DIFF
--- a/example/test/descriptor_test_gtest.cpp
+++ b/example/test/descriptor_test_gtest.cpp
@@ -79,14 +79,14 @@ TEST_F(DescriptorTest, check_lower_upper_bounds) {
 
 TEST_F(DescriptorTest, check_lt_eq) {
   EXPECT_EQ(descriptors_[3].integer_range.at(0).from_value,
-            std::numeric_limits<int>::lowest());
+            std::numeric_limits<int64_t>::lowest());
   EXPECT_EQ(descriptors_[3].integer_range.at(0).to_value, 15);
 }
 
 TEST_F(DescriptorTest, check_gt) {
   EXPECT_EQ(descriptors_[4].integer_range.at(0).from_value, 15);
   EXPECT_EQ(descriptors_[4].integer_range.at(0).to_value,
-            std::numeric_limits<int>::max());
+            std::numeric_limits<int64_t>::max());
 }
 
 int main(int argc, char** argv) {

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_parameter
@@ -26,10 +26,10 @@ descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1
 {%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int>::max();
+descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int64_t>::max();
 {%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
-descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int>::lowest();
+descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int64_t>::lowest();
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
 {%- endif %}
 {%- endif %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_runtime_parameter
@@ -42,10 +42,10 @@ descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1
 {%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
 descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int>::max();
+descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int64_t>::max();
 {%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.integer_range.resize({{loop.index}});
-descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int>::lowest();
+descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int64_t>::lowest();
 descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
Hi everyone,

This PR fixes #199. Since ROS uses int64_t to store integer parameters, int64_t numeric limits should be used instead of int.

i simply corrected the template files and the associated unit tests.

Any thoughts ?