### PR TITLE
Fix floating point range for upper/lt/lt_eq validations

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_parameter
@@ -15,7 +15,7 @@ descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.ar
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
 {%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
-descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
+descriptor.floating_point_range.at({{loop.index0}}).from_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
 {%- endif %}
 {%- elif "INTEGER" in parameter_type %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_runtime_parameter
@@ -31,7 +31,7 @@ descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.ar
 descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
 {%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
 descriptor.floating_point_range.resize({{loop.index}});
-descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::lowest();
+descriptor.floating_point_range.at({{loop.index0}}).from_value = std::numeric_limits<double>::lowest();
 descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
 {%- endif %}
 {%- elif "INTEGER" in parameter_type %}


### PR DESCRIPTION
As you can see the cpp templates are setting the `to_value` twice instead of the `from_value`. Probably a typo.

This leads to a wrong floating point range in the parameter descriptor.