### PR TITLE
Disable cache for `generate_parameter_library_cpp_BIN`

### DIFF
--- a/generate_parameter_library/cmake/generate_parameter_library.cmake
+++ b/generate_parameter_library/cmake/generate_parameter_library.cmake
@@ -28,6 +28,7 @@
 
 
 function(generate_parameter_library LIB_NAME YAML_FILE)
+  unset(generate_parameter_library_cpp_BIN CACHE)  # Unset the cache variable
   find_program(generate_parameter_library_cpp_BIN NAMES "generate_parameter_library_cpp")
   if(NOT generate_parameter_library_cpp_BIN)
     message(FATAL_ERROR "generate_parameter_library_cpp() variable 'generate_parameter_library_cpp_BIN' must not be empty")


### PR DESCRIPTION
The variable `generate_parameter_library_cpp_BIN` was cached, which caused build issues when switching between binary and source installed versions. This prevents the error `/opt/ros/humble/bin/generate_parameter_library_cpp: No such file or directory`.
`
 