### PR TITLE
Apply clang-tidy suggestions to `std::move` certain variables

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -105,7 +105,7 @@ struct StackParams {
 
     ParamListener(const std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>& parameters_interface,
                   rclcpp::Logger logger, std::string const& prefix = "") {
-      logger_ = logger;
+      logger_ = std::move(logger);
       prefix_ = prefix;
       if (!prefix_.empty() && prefix_.back() != '.') {
         prefix_ += ".";
@@ -210,7 +210,7 @@ struct StackParams {
     private:
       void update_internal_params(Params updated_params) {
         std::lock_guard<std::mutex> lock(mutex_);
-        params_ = updated_params;
+        params_ = std::move(updated_params);
       }
 
       std::string prefix_;


### PR DESCRIPTION
Closes https://github.com/PickNikRobotics/generate_parameter_library/issues/215