### PR TITLE
Fix flake8 error in publisher example

### DIFF
--- a/example_python/generate_parameter_module_example/minimal_publisher.py
+++ b/example_python/generate_parameter_module_example/minimal_publisher.py
@@ -36,6 +36,7 @@ import rclpy.node
 
 
 class MinimalParam(rclpy.node.Node):
+
     def __init__(self):
         super().__init__('admittance_controller')
         self.timer = self.create_timer(1, self.timer_callback)


### PR DESCRIPTION
CI was showing this failure:

```
build/generate_parameter_module_example/pytest.xml: 3 tests, 0 errors, 1 failure, 1 skipped
- generate_parameter_module_example.test.test_flake8 test_flake8
  <<< failure message
    AssertionError: Found 1 code style errors / warnings:
      ./generate_parameter_module_example/minimal_publisher.py:39:1: CNL100 Class definition does not have a new line.
    assert 1 == 0
  >>>
```