### PR TITLE
Use unique artifact name to upload logs on CI failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,9 +47,11 @@ jobs:
         with:
           name: test-results-${{ matrix.env.NAME }}
           path: ${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml
+          overwrite: true
       - name: Upload log artifacts (on failure)
         uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs-${{ matrix.env.NAME }}
           path: ${{ env.BASEDIR }}/target_ws/log/*
+          overwrite: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,5 +51,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: test-results-${{ matrix.env.NAME }}
+          name: test-results-log-${{ matrix.env.NAME }}
           path: ${{ env.BASEDIR }}/target_ws/log/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,5 +51,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: test-results-log-${{ matrix.env.NAME }}
+          name: logs-${{ matrix.env.NAME }}
           path: ${{ env.BASEDIR }}/target_ws/log/*


### PR DESCRIPTION
There is an issue when CI fails, in that both the test and log results artifacts uploaded on failure had the same name!

```
Run actions/upload-artifact@v4
With the provided path, there will be [12](https://github.com/PickNikRobotics/generate_parameter_library/actions/runs/12634499926/job/35202363937#step:5:13)2 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```