### PR TITLE
Replace iron CI with jazzy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,9 @@ jobs:
             ROS_REPO: testing
           - ROS_DISTRO: rolling
             ROS_REPO: main
-          - ROS_DISTRO: iron
+          - ROS_DISTRO: jazzy
             ROS_REPO: testing
-          - ROS_DISTRO: iron
+          - ROS_DISTRO: jazzy
             ROS_REPO: main
           - ROS_DISTRO: humble
             ROS_REPO: testing


### PR DESCRIPTION
Iron went EOL last November and Jazzy isn't on here yet.