### PR TITLE
Revert "Fix python lib install path (#207)"

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
@@ -55,6 +55,7 @@ def generate_parameter_module(module_name, yaml_file, validation_module=''):
             install_dir = os.path.join(
                 colcon_ws,
                 'install',
+                pkg_name,
                 'lib',
                 py_version,
                 'site-packages',


### PR DESCRIPTION
This reverts commit 4e92cc4e9da5e7a853ac0b1762db85e1f859d91b.

Turns out I took #207 in good faith, but it does cause problems.

Without that PR, this is what a custom module named `admittance_params.py` installs into. This is correct:

![image](https://github.com/user-attachments/assets/3a6f4e6b-bc04-4014-890e-abcbb5c243e1)

With that PR, it goes to the wrong folder one level up:

![image](https://github.com/user-attachments/assets/5869faba-be00-4226-a6a2-ffd868d4f4f2)
