### PR TITLE
fix: merge install for python packages

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
@@ -33,7 +33,7 @@ from generate_parameter_library_py.generate_python_module import run
 
 
 def generate_parameter_module(
-    module_name, yaml_file, validation_module='', merge_install_base=None
+    module_name, yaml_file, validation_module='', install_base=None, merge_install=False
 ):
     # TODO there must be a better way to do this. I need to find the build directory so I can place the python
     # module there
@@ -54,10 +54,11 @@ def generate_parameter_module(
             tmp = tmp.split('.')
             py_version = f'python{tmp[0]}.{tmp[1]}'
 
+            if not install_base:
+                install_base = os.path.join(colcon_ws, 'install')
+
             install_base = (
-                merge_install_base
-                if merge_install_base
-                else os.path.join(colcon_ws, 'install', pkg_name)
+                install_base if merge_install else os.path.join(install_base, pkg_name)
             )
             install_dir = os.path.join(
                 install_base,

--- a/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/setup_helper.py
@@ -32,7 +32,9 @@ import os
 from generate_parameter_library_py.generate_python_module import run
 
 
-def generate_parameter_module(module_name, yaml_file, validation_module=''):
+def generate_parameter_module(
+    module_name, yaml_file, validation_module='', merge_install_base=None
+):
     # TODO there must be a better way to do this. I need to find the build directory so I can place the python
     # module there
     build_dir = None
@@ -52,10 +54,13 @@ def generate_parameter_module(module_name, yaml_file, validation_module=''):
             tmp = tmp.split('.')
             py_version = f'python{tmp[0]}.{tmp[1]}'
 
+            install_base = (
+                merge_install_base
+                if merge_install_base
+                else os.path.join(colcon_ws, 'install', pkg_name)
+            )
             install_dir = os.path.join(
-                colcon_ws,
-                'install',
-                pkg_name,
+                install_base,
                 'lib',
                 py_version,
                 'site-packages',


### PR DESCRIPTION
Existing install of the parameter python script fails when using `colcon build` with `--merge-install` and/or `--install-base /opt/someuser/ros_ws`

This PR enables us to pass through a custom install base e.g. `/opt/someuser/ros_ws` as well as the merge-install flag for proper installation of python packages in the same way as `colcon build`.

One way to obtain the merge install path can be done as below and passed into `generate_parameter_module`. 
```
if len(sys.argv) >= 2 and sys.argv[1] != 'clean':
    from generate_parameter_library_py.setup_helper import generate_parameter_module
    
    colcon_prefix_path = os.getenv("COLCON_PREFIX_PATH", None)
    if not colcon_prefix_path:
        raise ValueError(f"Unable to find merge install base")    
    base_dir = colcon_prefix_path.split(':')[0] 

    generate_parameter_module(
        module_name="detector_onnx_parameters", 
        yaml_file="detector_onnx/detector_onnx_parameters.yaml", 
        install_base=base_dir,
        merge_install=True
    )
```

With this PR, running the following below commands in `/home/rosuser/ros_ws` (and editing the args above respectively), will place the auto-gen parameter script in the following:
```
> colcon build
/home/rosuser/ros_ws/install/my_package/lib/python3.12/site-packages/my_package/my_package_parameters.py

> colcon build --install-base /opt/myuser/ros_ws
/opt/myuser/ros_ws/my_package/lib/python3.12/site-packages/my_package/my_package_parameters.py

> colcon build --merge-install 
/home/rosuser/ros_ws/install/lib/python3.12/site-packages/my_package/my_package_parameters.py

> colcon build --merge-install --install-base /opt/myuser/ros_ws 
/opt/myuser/ros_ws/lib/python3.12/site-packages/my_package/my_package_parameters.py
```

