### PR TITLE
No need to default-construct logger in the declaration

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -105,9 +105,9 @@ struct StackParams {
     }
 
     ParamListener(const std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>& parameters_interface,
-                  rclcpp::Logger logger, std::string const& prefix = "") {
-      logger_ = std::move(logger);
-      prefix_ = prefix;
+                  rclcpp::Logger logger, std::string const& prefix = "")
+    : logger_{std::move(logger)},
+      prefix_{prefix} {
       if (!prefix_.empty() && prefix_.back() != '.') {
         prefix_ += ".";
       }
@@ -220,10 +220,7 @@ struct StackParams {
       std::shared_ptr<rclcpp::node_interfaces::OnSetParametersCallbackHandle> handle_;
       std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface_;
 
-      // rclcpp::Logger cannot be default-constructed
-      // so we must provide a initialization here even though
-      // every one of our constructors initializes logger_
-      rclcpp::Logger logger_ = rclcpp::get_logger("{{namespace}}");
+      rclcpp::Logger logger_;
       std::mutex mutable mutex_;
   };
 


### PR DESCRIPTION
I was browsing the code and came across this comment:

```c++
      // rclcpp::Logger cannot be default-constructed
      // so we must provide a initialization here
```

I didn't see why. And I thought: why not 'fix' it.