### PR TITLE
Improve `try_get_params` method

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -125,12 +125,12 @@ struct StackParams {
     }
 
     bool try_get_params(Params & params_in) const {
-      if (mutex_.try_lock()) {
+      std::unique_lock<std::mutex> lock(mutex_, std::try_to_lock);
+      if (lock.owns_lock()) {
         if (const bool is_old = params_in.__stamp != params_.__stamp; is_old) {
           params_in = params_;
+          return true;
         }
-        mutex_.unlock();
-        return true;
       }
       return false;
     }


### PR DESCRIPTION
Only return true when the parameters are modified and return false for others cases
I've also modified it to use the unique_lock as it is much better than try_lock on the mutex itself