### PR TITLE
-Wreorder compiler warnings fix

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -106,8 +106,8 @@ struct StackParams {
 
     ParamListener(const std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>& parameters_interface,
                   rclcpp::Logger logger, std::string const& prefix = "")
-    : logger_{std::move(logger)},
-      prefix_{prefix} {
+    : prefix_{prefix},
+      logger_{std::move(logger)} {
       if (!prefix_.empty() && prefix_.back() != '.') {
         prefix_ += ".";
       }


### PR DESCRIPTION
## Issue
Fix `-Wreorder` compiler warning in generated parameter header files

This issue is from ros-controls/ros2_controllers#1740, regarding `-Wreorder` compiler warnings in generated parameter header files. The issue is regarding initialized class members in a different order than they were declared.

```
/workspaces/ros2_rolling_ws/build/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster_parameters.hpp: In constructor ‘joint_state_broadcaster::ParamListener::ParamListener(const std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>&, rclcpp::Logger, const std::string&)’:
/workspaces/ros2_rolling_ws/build/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster_parameters.hpp:316:22: warning: ‘joint_state_broadcaster::ParamListener::logger_’ will be initialized after [-Wreorder]
  316 |       rclcpp::Logger logger_;
      |                      ^~~~~~~
/workspaces/ros2_rolling_ws/build/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster_parameters.hpp:309:19: warning:   ‘std::string joint_state_broadcaster::ParamListener::prefix_’ [-Wreorder]
  309 |       std::string prefix_;
      |                   ^~~~~~~
/workspaces/ros2_rolling_ws/build/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster_parameters.hpp:103:5: warning:   when initialized here [-Wreorder]
  103 |     ParamListener(const std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>& parameters_interface,
      |     ^~~~~~~~~~~~~
```

## Fixes
Reordered member initialization in the ParamListener constructor to match declaration order.