### PR TITLE
fix: make dataclasss public

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_struct
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_struct
@@ -1,4 +1,4 @@
-class __{{struct_name}}:
+class {{struct_name}}:
 {%- filter indent(width=4) %}
 {% if struct_fields|length -%}
 {{struct_fields-}}
@@ -8,13 +8,13 @@ class __{{struct_name}}:
 {% endif -%}
 {% endfilter -%}
 {% if struct_instance|length -%}
-{{struct_instance}} = __{{struct_name}}()
+{{struct_instance}} = {{struct_name}}()
 {% endif -%}
 {% if not struct_instance|length -%}
-__map_type = __{{struct_name}}
+_map_type = {{struct_name}}
 def add_entry(self, name):
     if not hasattr(self, name):
-        setattr(self, name, self.__map_type())
+        setattr(self, name, self._map_type())
     return getattr(self, name)
 def get_entry(self, name):
     return getattr(self, name)


### PR DESCRIPTION
Currently dataclasses generated in python look like:
```
class admittance_controller:

    class Params:
        # for detecting if the parameter struct has been updated
        stamp_ = Time()
        ...
        class __Pid:
            rate = 0.005
            class __MapJoints:
                p = 1.0
                i = None
                d = 1.0
            __map_type = __MapJoints
            def add_entry(self, name):
                if not hasattr(self, name):
                    setattr(self, name, self.__map_type())
                return getattr(self, name)
            def get_entry(self, name):
                return getattr(self, name)
        pid = __Pid()
```

The problem with this is you cannot access the child classes using `admittance_controller.Params.__Pid` because of the __. This PR changes this so the classes are no longer private.

```
class admittance_controller:

    class Params:
        # for detecting if the parameter struct has been updated
        stamp_ = Time()
        ...
        class __Pid:
            rate = 0.005
            class MapJoints:
                p = 1.0
                i = None
                d = 1.0
            _map_type = MapJoints
            def add_entry(self, name):
                if not hasattr(self, name):
                    setattr(self, name, self.__map_type())
                return getattr(self, name)
            def get_entry(self, name):
                return getattr(self, name)
        pid = Pid()
```

Given they were private before I don't expect this will cause any backwards compatbility issues.