### PR TITLE
feat: support plain node pointer in constructor

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -95,6 +95,9 @@ struct StackParams {
     ParamListener(rclcpp::Node::SharedPtr node, std::string const& prefix = "")
     : ParamListener(node->get_node_parameters_interface(), node->get_logger(), prefix) {}
 
+    ParamListener(rclcpp::Node* node, std::string const& prefix = "")
+    : ParamListener(node->get_node_parameters_interface(), node->get_logger(), prefix) {}
+
     ParamListener(rclcpp_lifecycle::LifecycleNode::SharedPtr node, std::string const& prefix = "")
     : ParamListener(node->get_node_parameters_interface(), node->get_logger(), prefix) {}
 


### PR DESCRIPTION
In order to construct the ParamListener in a node's constructor we are currently required to pass in a `shared_ptr<Node>` object, which is really only available after the constructor has finished. This allows `this` to be passed in to the constructor as the pointer.