### PR TITLE
Improve logging message when a parameter is not set

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/set_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/set_parameter
@@ -1,5 +1,5 @@
 param = parameters_interface_->get_parameter(prefix_ + "{{parameter_name}}");
-RCLCPP_DEBUG_STREAM(logger_, param.get_name() << ": " << param.get_type_name() << " = " << param.value_to_string());
+RCLCPP_DEBUG_STREAM(logger_, (prefix_ + "{{parameter_name}}") << ": " << param.get_type_name() << " = " << param.value_to_string());
 {% if parameter_validations|length -%}
 {{parameter_validations-}}
 {% endif -%}


### PR DESCRIPTION
Before: `[<NODE_NAME>]: : not set = not set`
After: `[<NODE_NAME>]: robot_description_planning.cartesian_limits.max_trans_vel: not set = not set`