### PR TITLE
Account for nested map params (#277)

### DIFF
--- a/parameter_traits/include/parameter_traits/parameter_traits.hpp
+++ b/parameter_traits/include/parameter_traits/parameter_traits.hpp
@@ -43,8 +43,8 @@ template <typename... Args>
 [[deprecated(
     "When returning tl::expected<void, std::string> you can call fmt::format "
     "directly.")]] auto
-ERROR(const std::string& format,
-      Args... args) -> tl::expected<void, std::string> {
+ERROR(const std::string& format, Args... args)
+    -> tl::expected<void, std::string> {
   return tl::make_unexpected(fmt::format(format, args...));
 }
 


### PR DESCRIPTION
Fixes how mapped params are handled so that nested params within map fields are also accounted for when generating the update/declaration blocks.

E.g.:
```yaml
example:
  keys:
    type: string_array

  key_structs:
    __map_keys:
      worked_fine:
        type: int
      nested:
        didnt_work: # This
          type: int
```

Still if multiple maps are stacked they need to be contiguous (same as before).

Fixes #277 .