### PR TITLE
Fix markdown generation for bounds/element-bounds

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/generate_markdown.py
@@ -67,6 +67,14 @@ class ParameterValidationMarkdown:
 
         self.validation = validation
 
+    @staticmethod
+    def format_arguments(arguments):
+        if not arguments:
+            return ''
+        if len(arguments) == 1:
+            return str(arguments[0])
+        return str(arguments)
+
     def get_validation_type(self, function_base_name):
         if function_base_name in self.sentence_conventions:
             return self.sentence_conventions[function_base_name]
@@ -77,9 +85,9 @@ class ParameterValidationMarkdown:
         arguments = self.validation.arguments
         validation = self.get_validation_type(self.validation.function_base_name)
         if validation.__contains__('VALUES'):
-            validation = validation.replace('VALUES', str(arguments[0]))
+            validation = validation.replace('VALUES', self.format_arguments(arguments))
         elif arguments:
-            validation += ': ' + str(arguments[0])
+            validation += ': ' + self.format_arguments(arguments)
 
         return ' - ' + validation
 

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -100,14 +100,3 @@ def test_parse_valid_parameter_files(yaml_test_file):
         set_up(yaml_test_file)
     except Exception as e:
         assert False, f'failed to parse valid file, reason:{e}'
-
-
-def test_markdown_includes_none_type_parameters():
-    yaml_test_file = 'valid_parameters_with_none_type.yaml'
-    set_up(yaml_test_file)
-
-    with open('/tmp/' + yaml_test_file + '.md') as markdown_file:
-        markdown = markdown_file.read()
-
-    assert '## some_external_parameter' in markdown
-    assert '* Type: `none`' not in markdown

--- a/generate_parameter_library_py/generate_parameter_library_py/test/test_markdown_generation.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/test_markdown_generation.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Austrian Institute of Technology GmbH (AIT)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+from unittest.mock import patch
+
+from ament_index_python.packages import get_package_share_path
+from generate_parameter_library_py.generate_cpp_header import parse_args
+from generate_parameter_library_py.generate_markdown import run as run_md
+
+
+def generate_markdown(yaml_test_file):
+    full_file_path = os.path.join(
+        get_package_share_path('generate_parameter_library_py'), 'test', yaml_test_file
+    )
+    output_file = '/tmp/' + yaml_test_file + '.md'
+    testargs = [sys.argv[0], output_file, full_file_path]
+    with patch.object(sys, 'argv', testargs):
+        args = parse_args()
+        run_md(args.input_yaml_file, args.output_cpp_header_file, 'markdown')
+    with open(output_file) as f:
+        return f.read()
+
+
+def test_none_type_parameters_are_included_but_not_typed():
+    """Parameters of type 'none' should appear as headings but without a Type line."""
+    markdown = generate_markdown('valid_parameters_with_none_type.yaml')
+
+    assert '## some_external_parameter' in markdown
+    assert '* Type: `none`' not in markdown
+
+
+def test_element_bounds_renders_both_lower_and_upper():
+    """element_bounds<> validation must show both lower and upper bound values."""
+    markdown = generate_markdown('valid_parameters.yaml')
+
+    # admittance.mass uses element_bounds<>: [ 0.0001, 1000000.0 ]
+    assert 'each element of array must be within bounds [0.0001, 1000000.0]' in markdown
+    # admittance.damping_ratio uses element_bounds<>: [ 0.1, 10.0 ]
+    assert 'each element of array must be within bounds [0.1, 10.0]' in markdown
+    # admittance.stiffness uses element_bounds (no <>): [ 0.0001, 100000.0 ]
+    assert 'each element of array must be within bounds [0.0001, 100000.0]' in markdown


### PR DESCRIPTION
Resolves #253 

Now 

```
generate_parameter_library_markdown --input_yaml example/src/parameters.yaml --output_markdown_file parameters.md
```
prints in markdown and similarly in rst language

```markdown
## one_number
 - parameter must be within bounds [1024, 65535]
```


```markdown
## admittance.mass
*Constraints:*
 - length must be equal to 6
 - each element of array must be within bounds [0.0001, 1000000.0]
```