### PR TITLE
Fix rst syntax

### DIFF
--- a/example_python/generate_parameter_module_example/minimal_publisher.py
+++ b/example_python/generate_parameter_module_example/minimal_publisher.py
@@ -81,6 +81,7 @@ def main(args=None):
         rclpy.spin(node)
     except KeyboardInterrupt:
         pass
-    
+
+
 if __name__ == '__main__':
     main()

--- a/example_python/generate_parameter_module_example/minimal_publisher.py
+++ b/example_python/generate_parameter_module_example/minimal_publisher.py
@@ -77,8 +77,10 @@ class MinimalParam(rclpy.node.Node):
 def main(args=None):
     rclpy.init(args=args)
     node = MinimalParam()
-    rclpy.spin(node)
-
-
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    
 if __name__ == '__main__':
     main()

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_parameter
@@ -1,6 +1,6 @@
 if not self.node_.has_parameter(self.prefix_ + "{{parameter_name}}"):
 {%- filter indent(width=4) %}
-descriptor = ParameterDescriptor(description="{{parameter_description|valid_string_python}}", read_only = {{parameter_read_only}})
+descriptor = ParameterDescriptor(description=r"{{parameter_description|valid_string_python}}", read_only = {{parameter_read_only}})
 {%- if parameter_additional_constraints|length %}
 descriptor.additional_constraints = "{{parameter_additional_constraints|valid_string_python}}"
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_runtime_parameter
@@ -15,7 +15,7 @@ param_name = f"{self.prefix_}{% for map in parameter_map%}{value_{{loop.index}}}
 {% endif -%}
 if not self.node_.has_parameter(self.prefix_ + param_name):
 {%- filter indent(width=4) %}
-descriptor = ParameterDescriptor(description="{{parameter_description|valid_string_python}}", read_only = {{parameter_read_only}})
+descriptor = ParameterDescriptor(description=r"{{parameter_description|valid_string_python}}", read_only = {{parameter_read_only}})
 {%- if parameter_additional_constraints|length %}
 descriptor.additional_constraints = "{{parameter_additional_constraints|valid_string_python}}"
 {% endif -%}


### PR DESCRIPTION
This PR aims to solve #326. It changes how Python reads the string to 'raw mode', so it doesn't use backslash as an escape character. 

Unfortunately, it causes an error if the string ends in a backslash, as the interpreter can't see the closing string character (`'` or `"`). I think it's not worth addressing this, as the user can add a white space if a backlash at the end of the description is really necessary.

Here is the expected error if someone Google it in the future:

```bash
print(r'testing raw\')
  File "<stdin>", line 1
    print(r'testing raw\') # Just remove the \ at the end
          ^
SyntaxError: unterminated string literal (detected at line 1)
```
