### PR TITLE
replace rsl::StaticVector by std::array

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/cpp_conversions.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/cpp_conversions.py
@@ -49,9 +49,9 @@ class CPPConversions:
             'double_array': lambda defined_type, templates: 'std::vector<double>',
             'int_array': lambda defined_type, templates: 'std::vector<int64_t>',
             'string_array': lambda defined_type, templates: 'std::vector<std::string>',
-            'double_array_fixed': lambda defined_type, templates: f'rsl::StaticVector<{templates[0]}, {templates[1]}>',
-            'int_array_fixed': lambda defined_type, templates: f'rsl::StaticVector<{templates[0]}, {templates[1]}>',
-            'string_array_fixed': lambda defined_type, templates: f'rsl::StaticVector<{templates[0]}, {templates[1]}>',
+            'double_array_fixed': lambda defined_type, templates: f'std::array<{templates[0]}, {templates[1]}>',
+            'int_array_fixed': lambda defined_type, templates: f'std::array<{templates[0]}, {templates[1]}>',
+            'string_array_fixed': lambda defined_type, templates: f'std::array<{templates[0]}, {templates[1]}>',
             'string_fixed': lambda defined_type, templates: f'rsl::StaticString<{templates[1]}>',
         }
         self.yaml_type_to_as_function = {

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -22,7 +22,6 @@
 #include <fmt/ranges.h>
 
 #include <rsl/static_string.hpp>
-#include <rsl/static_vector.hpp>
 #include <rsl/parameter_validators.hpp>
 
 {% if user_validation_file|length -%}
@@ -60,8 +59,8 @@ template <size_t capacity>
 }
 
 template <typename T, size_t capacity>
-[[nodiscard]] auto to_parameter_value(rsl::StaticVector<T, capacity> const& value) {
-    return rclcpp::ParameterValue(rsl::to_vector(value));
+[[nodiscard]] auto to_parameter_value(std::array<T, capacity> const& value) {
+    return rclcpp::ParameterValue(std::vector<T>{value.begin(), value.end()});
 }
 
 {%- filter indent(width=4) %}


### PR DESCRIPTION
`std::array<T, N>` is more commonly used and has compiler checks for assigning more values than the array can hold.