### PR TITLE
Warn on conflicting validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ The built-in validator functions provided by this package are:
 | gt_eq<>  | [value]             | parameter >= value                   |
 | one_of<> | [[val1, val2, ...]] | Value is one of the specified values |
 
+Note: `lt<>`, `gt<>`, `lt_eq<>`, or `gt_eq<>` cannot be used together with `bounds<>`.
+
 **String validators**
 | Function     | Arguments           | Description                                    |
 | ------------ | ------------------- | ---------------------------------------------- |
@@ -285,6 +287,8 @@ The built-in validator functions provided by this package are:
 | element_bounds<>       | [lower, upper]      | Bounds checking each element (inclusive)            |
 | lower_element_bounds<> | [lower]             | Lower bound for each element (inclusive)            |
 | upper_element_bounds<> | [upper]             | Upper bound for each element (inclusive)            |
+
+Note: `element_bounds<>` cannot be mixed with `lower_element_bounds<>` or `upper_element_bounds<>`.
 
 ### Custom validator functions
 Validators are functions that return a `tl::expected<void, std::string>` type and accept a `rclcpp::Parameter const&` as their first argument and any number of arguments after that can be specified in YAML.

--- a/example/src/parameters.yaml
+++ b/example/src/parameters.yaml
@@ -29,6 +29,15 @@ admittance_controller:
         validation:
           gt<>: [0.0]
 
+      limit:
+        type: double_array
+        description: "specifies limit for x, y and z axis"
+        default_value: [0.0, 0.0, 0.0]
+        validation:
+          fixed_size<>: 3
+          lower_element_bounds<>: -10.0
+          upper_element_bounds<>: 10.0
+
   nested_dynamic:
     __map_joints:
       __map_dof_names:
@@ -231,6 +240,15 @@ admittance_controller:
       validation:
         element_bounds: [ 0.0001, 100000.0 ]
 
+  acceleration_limits:
+    type: double_array
+    description: "specifies maximum acceleration limits for x, y and z axis"
+    default_value: [0.0, 0.0, 0.0]
+    validation:
+      fixed_size<>: 3
+      lower_element_bounds<>: -10.0
+      upper_element_bounds<>: 10.0
+
   # general settings
   enable_parameter_update_without_reactivation:
     type: bool
@@ -252,6 +270,20 @@ admittance_controller:
     description: "should be a number greater than 15"
     validation:
       gt<>: [ 15 ]
+  gt_fifteen_lt_eq_twenty:
+    type: int
+    default_value: 20
+    description: "should be a number greater than 15 and less than or equal to 20"
+    validation:
+      gt<>: [ 15 ]
+      lt_eq<>: [ 20 ]
+  gt_fifteen_lt_twenty:
+    type: int
+    default_value: 16
+    description: "should be a number greater than 15 and less than 20"
+    validation:
+      gt<>: [ 15 ]
+      lt<>: [ 20 ]
   one_number:
     type: int
     default_value: 14540

--- a/example_python/generate_parameter_module_example/parameters.yaml
+++ b/example_python/generate_parameter_module_example/parameters.yaml
@@ -35,6 +35,15 @@ admittance_controller:
         validation:
           gt<>: [0.0]
 
+      limit:
+        type: double_array
+        description: "specifies limit for x, y and z axis"
+        default_value: [0.0, 0.0, 0.0]
+        validation:
+          fixed_size<>: 3
+          lower_element_bounds<>: -10.0
+          upper_element_bounds<>: 10.0
+
   nested_dynamic:
     __map_joints:
       __map_dof_names:
@@ -234,6 +243,15 @@ admittance_controller:
       validation:
         element_bounds: [ 0.0001, 100000.0 ]
 
+  acceleration_limits:
+    type: double_array
+    description: "specifies maximum acceleration limits for x, y and z axis"
+    default_value: [0.0, 0.0, 0.0]
+    validation:
+      fixed_size<>: 3
+      lower_element_bounds<>: -10.0
+      upper_element_bounds<>: 10.0
+
   # general settings
   enable_parameter_update_without_reactivation:
     type: bool
@@ -255,6 +273,20 @@ admittance_controller:
     description: "should be a number greater than 15"
     validation:
       gt<>: [ 15 ]
+  gt_fifteen_lt_eq_twenty:
+    type: int
+    default_value: 20
+    description: "should be a number greater than 15 and less than or equal to 20"
+    validation:
+      gt<>: [ 15 ]
+      lt_eq<>: [ 20 ]
+  gt_fifteen_lt_twenty:
+    type: int
+    default_value: 16
+    description: "should be a number greater than 15 and less than 20"
+    validation:
+      gt<>: [ 15 ]
+      lt<>: [ 20 ]
   one_number:
     type: int
     default_value: 14540

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_parameter
@@ -6,37 +6,41 @@ descriptor.read_only = {{parameter_read_only}};
 {%- if parameter_additional_constraints|length %}
 descriptor.additional_constraints = {{parameter_additional_constraints | valid_string_cpp}};
 {% endif -%}
-{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if "DOUBLE" in parameter_type %}
+{%- set range = namespace(lower=None, upper=None) %}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if validation.arguments|length == 2 %}
-descriptor.floating_point_range.resize({{loop.index}});
-descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
+{%- set range.lower = validation.arguments[0] %}
+{%- set range.upper = validation.arguments[1] %}
 {%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.floating_point_range.resize({{loop.index}});
-descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
+{%- set range.lower = validation.arguments[0] %}
 {%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.floating_point_range.resize({{loop.index}});
-descriptor.floating_point_range.at({{loop.index0}}).from_value = std::numeric_limits<double>::lowest();
-descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
-{%- endif %}
-{%- elif "INTEGER" in parameter_type %}
-{%- if validation.arguments|length == 2 %}
-descriptor.integer_range.resize({{loop.index}});
-descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.integer_range.resize({{loop.index}});
-descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int64_t>::max();
-{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.integer_range.resize({{loop.index}});
-descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int64_t>::lowest();
-descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
-{%- endif %}
+{%- set range.upper = validation.arguments[0] %}
 {%- endif %}
 {%- endfor %}
+{%- if range.lower is not none or range.upper is not none %}
+descriptor.floating_point_range.resize(1);
+descriptor.floating_point_range.at(0).from_value = {{range.lower if range.lower is not none else "std::numeric_limits<double>::lowest()"}};
+descriptor.floating_point_range.at(0).to_value = {{range.upper if range.upper is not none else "std::numeric_limits<double>::max()"}};
+{%- endif %}
+{%- elif "INTEGER" in parameter_type %}
+{%- set range = namespace(lower=None, upper=None) %}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
+{%- if validation.arguments|length == 2 %}
+{%- set range.lower = validation.arguments[0] %}
+{%- set range.upper = validation.arguments[1] %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
+{%- set range.lower = validation.arguments[0] %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
+{%- set range.upper = validation.arguments[0] %}
+{%- endif %}
+{%- endfor %}
+{%- if range.lower is not none or range.upper is not none %}
+descriptor.integer_range.resize(1);
+descriptor.integer_range.at(0).from_value = {{range.lower if range.lower is not none else "std::numeric_limits<int64_t>::lowest()"}};
+descriptor.integer_range.at(0).to_value = {{range.upper if range.upper is not none else "std::numeric_limits<int64_t>::max()"}};
+{%- endif %}
+{%- endif %}
 {%- if not parameter_value|length %}
 auto parameter = rclcpp::ParameterType::PARAMETER_{{parameter_type}};
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/declare_runtime_parameter
@@ -22,37 +22,41 @@ descriptor.read_only = {{parameter_read_only}};
 {%- if parameter_additional_constraints|length %}
 descriptor.additional_constraints = {{parameter_additional_constraints | valid_string_cpp}};
 {% endif -%}
-{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if "DOUBLE" in parameter_type %}
+{%- set range = namespace(lower=None, upper=None) %}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if validation.arguments|length == 2 %}
-descriptor.floating_point_range.resize({{loop.index}});
-descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
+{%- set range.lower = validation.arguments[0] %}
+{%- set range.upper = validation.arguments[1] %}
 {%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.floating_point_range.resize({{loop.index}});
-descriptor.floating_point_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.floating_point_range.at({{loop.index0}}).to_value = std::numeric_limits<double>::max();
+{%- set range.lower = validation.arguments[0] %}
 {%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.floating_point_range.resize({{loop.index}});
-descriptor.floating_point_range.at({{loop.index0}}).from_value = std::numeric_limits<double>::lowest();
-descriptor.floating_point_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
-{%- endif %}
-{%- elif "INTEGER" in parameter_type %}
-{%- if validation.arguments|length == 2 %}
-descriptor.integer_range.resize({{loop.index}});
-descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[1]}};
-{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.integer_range.resize({{loop.index}});
-descriptor.integer_range.at({{loop.index0}}).from_value = {{validation.arguments[0]}};
-descriptor.integer_range.at({{loop.index0}}).to_value = std::numeric_limits<int64_t>::max();
-{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.integer_range.resize({{loop.index}});
-descriptor.integer_range.at({{loop.index0}}).from_value = std::numeric_limits<int64_t>::lowest();
-descriptor.integer_range.at({{loop.index0}}).to_value = {{validation.arguments[0]}};
-{%- endif %}
+{%- set range.upper = validation.arguments[0] %}
 {%- endif %}
 {%- endfor %}
+{%- if range.lower is not none or range.upper is not none %}
+descriptor.floating_point_range.resize(1);
+descriptor.floating_point_range.at(0).from_value = {{range.lower if range.lower is not none else "std::numeric_limits<double>::lowest()"}};
+descriptor.floating_point_range.at(0).to_value = {{range.upper if range.upper is not none else "std::numeric_limits<double>::max()"}};
+{%- endif %}
+{%- elif "INTEGER" in parameter_type %}
+{%- set range = namespace(lower=None, upper=None) %}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
+{%- if validation.arguments|length == 2 %}
+{%- set range.lower = validation.arguments[0] %}
+{%- set range.upper = validation.arguments[1] %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
+{%- set range.lower = validation.arguments[0] %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
+{%- set range.upper = validation.arguments[0] %}
+{%- endif %}
+{%- endfor %}
+{%- if range.lower is not none or range.upper is not none %}
+descriptor.integer_range.resize(1);
+descriptor.integer_range.at(0).from_value = {{range.lower if range.lower is not none else "std::numeric_limits<int64_t>::lowest()"}};
+descriptor.integer_range.at(0).to_value = {{range.upper if range.upper is not none else "std::numeric_limits<int64_t>::max()"}};
+{%- endif %}
+{%- endif %}
 {%- if not default_value|length %}
 auto parameter = rclcpp::ParameterType::PARAMETER_{{parameter_type}};
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_parameter
@@ -4,37 +4,41 @@ descriptor = ParameterDescriptor(description=r"{{parameter_description|valid_str
 {%- if parameter_additional_constraints|length %}
 descriptor.additional_constraints = "{{parameter_additional_constraints|valid_string_python}}"
 {% endif -%}
-{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if "DOUBLE" in parameter_type %}
+{%- set range = namespace(lower=None, upper=None) %}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if validation.arguments|length == 2 %}
-descriptor.floating_point_range.append(FloatingPointRange())
-descriptor.floating_point_range[-1].from_value = {{validation.arguments[0]}}
-descriptor.floating_point_range[-1].to_value = {{validation.arguments[1]}}
+{%- set range.lower = validation.arguments[0] %}
+{%- set range.upper = validation.arguments[1] %}
 {%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.floating_point_range.append(FloatingPointRange())
-descriptor.floating_point_range[-1].from_value = {{validation.arguments[0]}}
-descriptor.floating_point_range[-1].to_value = float('inf')
+{%- set range.lower = validation.arguments[0] %}
 {%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.floating_point_range.append(FloatingPointRange())
-descriptor.floating_point_range[-1].from_value = -float('inf')
-descriptor.floating_point_range[-1].to_value = {{validation.arguments[0]}}
-{%- endif %}
-{%- elif "INTEGER" in parameter_type %}
-{%- if validation.arguments|length == 2 %}
-descriptor.integer_range.append(IntegerRange())
-descriptor.integer_range[-1].from_value = {{validation.arguments[0]}}
-descriptor.integer_range[-1].to_value = {{validation.arguments[1]}}
-{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.integer_range.append(IntegerRange())
-descriptor.integer_range[-1].from_value = {{validation.arguments[0]}}
-descriptor.integer_range[-1].to_value = 2**31-1
-{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.integer_range.append(IntegerRange())
-descriptor.integer_range[-1].from_value = -2**31-1
-descriptor.integer_range[-1].to_value = {{validation.arguments[0]}}
-{%- endif %}
+{%- set range.upper = validation.arguments[0] %}
 {%- endif %}
 {%- endfor %}
+{%- if range.lower is not none or range.upper is not none %}
+descriptor.floating_point_range.append(FloatingPointRange())
+descriptor.floating_point_range[-1].from_value = {{range.lower if range.lower is not none else "-float('inf')"}}
+descriptor.floating_point_range[-1].to_value = {{range.upper if range.upper is not none else "float('inf')"}}
+{%- endif %}
+{%- elif "INTEGER" in parameter_type %}
+{%- set range = namespace(lower=None, upper=None) %}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
+{%- if validation.arguments|length == 2 %}
+{%- set range.lower = validation.arguments[0] %}
+{%- set range.upper = validation.arguments[1] %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
+{%- set range.lower = validation.arguments[0] %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
+{%- set range.upper = validation.arguments[0] %}
+{%- endif %}
+{%- endfor %}
+{%- if range.lower is not none or range.upper is not none %}
+descriptor.integer_range.append(IntegerRange())
+descriptor.integer_range[-1].from_value = {{range.lower if range.lower is not none else "-2**31-1"}}
+descriptor.integer_range[-1].to_value = {{range.upper if range.upper is not none else "2**31-1"}}
+{%- endif %}
+{%- endif %}
 {%- if not parameter_value|length %}
 parameter = rclpy.Parameter.Type.{{parameter_type}}
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/declare_runtime_parameter
@@ -19,37 +19,41 @@ descriptor = ParameterDescriptor(description=r"{{parameter_description|valid_str
 {%- if parameter_additional_constraints|length %}
 descriptor.additional_constraints = "{{parameter_additional_constraints|valid_string_python}}"
 {% endif -%}
-{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if "DOUBLE" in parameter_type %}
+{%- set range = namespace(lower=None, upper=None) %}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
 {%- if validation.arguments|length == 2 %}
-descriptor.floating_point_range.append(FloatingPointRange())
-descriptor.floating_point_range[-1].from_value = {{validation.arguments[0]}}
-descriptor.floating_point_range[-1].to_value = {{validation.arguments[1]}}
+{%- set range.lower = validation.arguments[0] %}
+{%- set range.upper = validation.arguments[1] %}
 {%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.floating_point_range.append(FloatingPointRange())
-descriptor.floating_point_range[-1].from_value = {{validation.arguments[0]}}
-descriptor.floating_point_range[-1].to_value = float('inf')
+{%- set range.lower = validation.arguments[0] %}
 {%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.floating_point_range.append(FloatingPointRange())
-descriptor.floating_point_range[-1].from_value = -float('inf')
-descriptor.floating_point_range[-1].to_value = {{validation.arguments[0]}}
-{%- endif %}
-{%- elif "INTEGER" in parameter_type %}
-{%- if validation.arguments|length == 2 %}
-descriptor.integer_range.append(IntegerRange())
-descriptor.integer_range[-1].from_value = {{validation.arguments[0]}}
-descriptor.integer_range[-1].to_value = {{validation.arguments[1]}}
-{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.integer_range.append(IntegerRange())
-descriptor.integer_range[-1].from_value = {{validation.arguments[0]}}
-descriptor.integer_range[-1].to_value = 2**31-1
-{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
-descriptor.integer_range.append(IntegerRange())
-descriptor.integer_range[-1].from_value = -2**31-1
-descriptor.integer_range[-1].to_value = {{validation.arguments[0]}}
-{%- endif %}
+{%- set range.upper = validation.arguments[0] %}
 {%- endif %}
 {%- endfor %}
+{%- if range.lower is not none or range.upper is not none %}
+descriptor.floating_point_range.append(FloatingPointRange())
+descriptor.floating_point_range[-1].from_value = {{range.lower if range.lower is not none else "-float('inf')"}}
+descriptor.floating_point_range[-1].to_value = {{range.upper if range.upper is not none else "float('inf')"}}
+{%- endif %}
+{%- elif "INTEGER" in parameter_type %}
+{%- set range = namespace(lower=None, upper=None) %}
+{%- for validation in parameter_validations if ("bounds" in validation.function_name or "lt" in validation.function_name or "gt" in validation.function_name) %}
+{%- if validation.arguments|length == 2 %}
+{%- set range.lower = validation.arguments[0] %}
+{%- set range.upper = validation.arguments[1] %}
+{%- elif ("lower" in validation.function_name or "gt" == validation.function_base_name or "gt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
+{%- set range.lower = validation.arguments[0] %}
+{%- elif ("upper" in validation.function_name or "lt" == validation.function_base_name or "lt_eq" == validation.function_base_name) and validation.arguments|length == 1 %}
+{%- set range.upper = validation.arguments[0] %}
+{%- endif %}
+{%- endfor %}
+{%- if range.lower is not none or range.upper is not none %}
+descriptor.integer_range.append(IntegerRange())
+descriptor.integer_range[-1].from_value = {{range.lower if range.lower is not none else "-2**31-1"}}
+descriptor.integer_range[-1].to_value = {{range.upper if range.upper is not none else "2**31-1"}}
+{%- endif %}
+{%- endif %}
 {%- if not default_value|length %}
 parameter = rclpy.Parameter.Type.{{parameter_type}}
 {% endif -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -42,6 +42,7 @@ from typing import Any, List, Union
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
 import os
+import sys
 import yaml
 
 from generate_parameter_library_py.cpp_conversions import CPPConversions
@@ -62,9 +63,20 @@ class YAMLSyntaxError(Exception):
 
 
 # helper functions
+_warned_param_names = set()
+
+
 @typechecked
 def compile_error(msg: str):
     return YAMLSyntaxError('\nERROR: ' + msg)
+
+
+@typechecked
+def compile_warning(param_name: str, msg: str):
+    if param_name in _warned_param_names:
+        return
+    _warned_param_names.add(param_name)
+    print('\nWARNING: ' + msg, file=sys.stderr, flush=True)
 
 
 @typechecked
@@ -111,20 +123,21 @@ def validate_validator_combinations(param_name: str, validations_dict: dict):
         'lower_element_bounds',
         'upper_element_bounds',
     }.intersection(validation_names):
-        raise compile_error(
-            "Parameter {} cannot combine 'element_bounds' with 'lower_element_bounds/upper_element_bounds'.".format(
-                param_name
-            )
+        compile_warning(
+            param_name,
+            "Parameter '{}' combines 'element_bounds' with 'lower_element_bounds/upper_element_bounds'. "
+            "'element_bounds' will take precedence.".format(param_name),
         )
 
     scalar_bound_validators = {'gt', 'gt_eq', 'lt', 'lt_eq'}
     if 'bounds' in validation_names and validation_names.intersection(
         scalar_bound_validators
     ):
-        raise compile_error(
-            "Parameter {} cannot combine 'bounds' with scalar bound validators "
+        compile_warning(
+            param_name,
+            "Parameter '{}' cannot combine 'bounds' with scalar bound validators "
             "(gt/gt_eq/lt/lt_eq). Use only 'bounds<>' for inclusive ranges, "
-            'or only scalar bound validators.'.format(param_name)
+            'or only scalar bound validators.'.format(param_name),
         )
 
 

--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -98,6 +98,36 @@ def int_to_integer_str(value: str):
     return value.replace('int', 'integer')
 
 
+@typechecked
+def validation_base_name(function_name: str):
+    return function_name.replace('<>', '')
+
+
+@typechecked
+def validate_validator_combinations(param_name: str, validations_dict: dict):
+    validation_names = {validation_base_name(name) for name in validations_dict}
+
+    if 'element_bounds' in validation_names and {
+        'lower_element_bounds',
+        'upper_element_bounds',
+    }.intersection(validation_names):
+        raise compile_error(
+            "Parameter {} cannot combine 'element_bounds' with 'lower_element_bounds/upper_element_bounds'.".format(
+                param_name
+            )
+        )
+
+    scalar_bound_validators = {'gt', 'gt_eq', 'lt', 'lt_eq'}
+    if 'bounds' in validation_names and validation_names.intersection(
+        scalar_bound_validators
+    ):
+        raise compile_error(
+            "Parameter {} cannot combine 'bounds' with scalar bound validators "
+            "(gt/gt_eq/lt/lt_eq). Use only 'bounds<>' for inclusive ranges, "
+            'or only scalar bound validators.'.format(param_name)
+        )
+
+
 def get_dynamic_parameter_field(yaml_parameter_name: str):
     tmp = yaml_parameter_name.split('.')
     num_nested = [i for i, val in enumerate(tmp) if is_mapped_parameter(val)]
@@ -748,6 +778,8 @@ def preprocess_inputs(language, name, value, nested_name_list):
     validations_dict = value.get('validation', {})
     if is_fixed_type(defined_type):
         validations_dict['size_lt<>'] = fixed_type_size(defined_type) + 1
+
+    validate_validator_combinations(param_name, validations_dict)
 
     for func_name in validations_dict:
         args = validations_dict[func_name]

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -74,8 +74,6 @@ def set_up(yaml_test_file):
             'missing_type.yaml',
             'invalid_syntax.yaml',
             'invalid_parameter_type.yaml',
-            'conflicting_element_bounds.yaml',
-            'conflicting_scalar_bounds_with_bounds.yaml',
         ]
     ],
 )
@@ -91,6 +89,8 @@ def test_expected(test_input, expected):
     [
         ('valid_parameters.yaml'),
         ('valid_parameters_with_none_type.yaml'),
+        ('conflicting_element_bounds.yaml'),
+        ('conflicting_scalar_bounds_with_bounds.yaml'),
         ('nested_map_test.yaml'),
         ('nested_map_keys.yaml'),
     ],

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -74,6 +74,8 @@ def set_up(yaml_test_file):
             'missing_type.yaml',
             'invalid_syntax.yaml',
             'invalid_parameter_type.yaml',
+            'conflicting_element_bounds.yaml',
+            'conflicting_scalar_bounds_with_bounds.yaml',
         ]
     ],
 )

--- a/generate_parameter_library_py/generate_parameter_library_py/test/conflicting_element_bounds.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/conflicting_element_bounds.yaml
@@ -1,0 +1,8 @@
+admittance_controller:
+  acceleration_limits:
+    type: double_array
+    description: "specifies maximum acceleration limits for x, y and z axis"
+    validation:
+      fixed_size<>: 3
+      element_bounds<>: [-10.0, 20.0]
+      upper_element_bounds<>: 10.0

--- a/generate_parameter_library_py/generate_parameter_library_py/test/conflicting_scalar_bounds_with_bounds.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/conflicting_scalar_bounds_with_bounds.yaml
@@ -1,0 +1,8 @@
+admittance_controller:
+  conflicting_bounds:
+    type: int
+    default_value: 16
+    description: "should be a number between 10 and 20"
+    validation:
+      bounds<>: [ 10, 20 ]
+      lt_eq<>: [ 20 ]

--- a/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
@@ -34,6 +34,37 @@ admittance_controller:
         type: double
         default_value: 1.0
         description: "derivative gain term"
+
+      limit:
+        type: double_array
+        description: "specifies limit for x, y and z axis"
+        default_value: [0.0, 0.0, 0.0]
+        validation:
+          fixed_size<>: 3
+          lower_element_bounds<>: -10.0
+          upper_element_bounds<>: 10.0
+
+  gt_fifteen_lt_eq_twenty:
+    type: int
+    default_value: 20
+    description: "should be a number greater than 15 and less than or equal to 20"
+    validation:
+      gt<>: [ 15 ]
+      lt_eq<>: [ 20 ]
+  gt_fifteen_lt_twenty:
+    type: int
+    default_value: 16
+    description: "should be a number greater than 15 and less than 20"
+    validation:
+      gt<>: [ 15 ]
+      lt<>: [ 20 ]
+  acceleration_limits:
+    type: double_array
+    description: "specifies maximum acceleration limits for x, y and z axis"
+    validation:
+      fixed_size<>: 3
+      lower_element_bounds<>: -10.0
+      upper_element_bounds<>: 10.0
   fixed_string:
     type: string_fixed_25
     default_value: "string_value"

--- a/generate_parameter_library_py/setup.py
+++ b/generate_parameter_library_py/setup.py
@@ -57,6 +57,16 @@ setup(
         ),
         (
             'share/' + package_name + '/test',
+            ['generate_parameter_library_py/test/conflicting_element_bounds.yaml'],
+        ),
+        (
+            'share/' + package_name + '/test',
+            [
+                'generate_parameter_library_py/test/conflicting_scalar_bounds_with_bounds.yaml'
+            ],
+        ),
+        (
+            'share/' + package_name + '/test',
             ['generate_parameter_library_py/test/valid_parameters.yaml'],
         ),
         (


### PR DESCRIPTION
Similar to  #336, but print a warning instead of throwing an exception 
```
$ colcon build --packages-select generate_parameter_module_example 
Starting >>> generate_parameter_module_example
--- stderr: generate_parameter_module_example                   

WARNING: Parameter 'conflicting_bounds' cannot combine 'bounds' with scalar bound validators (gt/gt_eq/lt/lt_eq). Use only 'bounds<>' for inclusive ranges, or only scalar bound validators.
---
Finished <<< generate_parameter_module_example [3.75s]

Summary: 1 package finished [4.01s]
  1 package had stderr output: generate_parameter_module_example
```