### PR TITLE
Generate markdown documentation also for none type

### DIFF
--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/markdown/parameter_detail
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/markdown/parameter_detail
@@ -2,7 +2,9 @@
 {% if description|length %}
 {{description}}
 {% endif %}
+{% if type != 'none' %}
 * Type: `{{type}}`
+{% endif %}
 {%- if default_value|length %}
 * Default Value: {{default_value}}{% endif %}{% if read_only %}
 * Read only: {{read_only}}{% endif %}{%- if constraints|length %}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/parameter_detail
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/rst/parameter_detail
@@ -1,4 +1,4 @@
-{{name}} ({{type}}){%- filter indent(width=2) %}{% if description|length %}
+{{name}}{% if type != 'none' %} ({{type}}){% endif %}{%- filter indent(width=2) %}{% if description|length %}
 {{description}}
 {% endif %}
 {%- if read_only %}

--- a/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/parse_yaml.py
@@ -855,8 +855,12 @@ class GenerateCode:
             validations,
             additional_constraints,
         ) = preprocess_inputs(self.language, name, value, nested_name_list)
-        # skip accepted params that do not generate code
-        if code_gen_variable.lang_type is None:
+        # Skip accepted params that do not generate code for code-generation targets.
+        # Documentation targets still need to keep these entries (e.g. type: none).
+        if code_gen_variable.lang_type is None and self.language not in {
+            'markdown',
+            'rst',
+        }:
             return
 
         param_name = code_gen_variable.param_name

--- a/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/YAML_parse_error_test.py
@@ -100,3 +100,14 @@ def test_parse_valid_parameter_files(yaml_test_file):
         set_up(yaml_test_file)
     except Exception as e:
         assert False, f'failed to parse valid file, reason:{e}'
+
+
+def test_markdown_includes_none_type_parameters():
+    yaml_test_file = 'valid_parameters_with_none_type.yaml'
+    set_up(yaml_test_file)
+
+    with open('/tmp/' + yaml_test_file + '.md') as markdown_file:
+        markdown = markdown_file.read()
+
+    assert '## some_external_parameter' in markdown
+    assert '* Type: `none`' not in markdown


### PR DESCRIPTION
Closes #266

```bash
$ generate_parameter_library_markdown --input_yaml src/ros2_controllers/chained_filter_controller/src/chained_filter_parameters.yaml --output_markdown test.md
```

Before:

> # Chained Filter Parameters
> 
> Default Config
> ```yaml
> chained_filter:
>   ros__parameters:
>     input_interfaces: '{}'
>     output_interfaces: '{}'
> 
> ```
> 
> ## input_interfaces
> 
> Name of the input state interface
> 
> * Type: `string_array`
> * Default Value: {}
> * Read only: True
> 
> *Constraints:*
>  - parameter is not empty
> 
> *Additional Constraints:*
> 
> 
> 
> ## output_interfaces
> 
> Name of the output state interface
> 
> * Type: `string_array`
> * Default Value: {}
> * Read only: True
> 
> *Constraints:*
>  - parameter is not empty
> 
> *Additional Constraints:*




After:

> # Chained Filter Parameters
> 
> Default Config
> ```yaml
> chained_filter:
>   ros__parameters:
>     <input_interfaces>:
>       filter_chain: ''
>     filter_chain: ''
>     input_interfaces: '{}'
>     output_interfaces: '{}'
> 
> ```
> 
> ## input_interfaces
> 
> Name of the input state interface
> 
> 
> * Type: `string_array`
> 
> * Default Value: {}
> * Read only: True
> 
> *Constraints:*
>  - parameter is not empty
> 
> *Additional Constraints:*
> 
> 
> 
> ## output_interfaces
> 
> Name of the output state interface
> 
> 
> * Type: `string_array`
> 
> * Default Value: {}
> * Read only: True
> 
> *Constraints:*
>  - parameter is not empty
> 
> *Additional Constraints:*
> 
> 
> 
> ## filter_chain
> 
> Map of parameters that defines a filter chain, containing filterN as key. Valid for all interfaces, overrides <input_interfaces>.filter_chain if set. The fields for each filter are: type: The filter plugin to be loaded name: Actual name semantically describing the filter, e.g., low_pass_filter params: And underlying map of parameters needed for a specific filter, refer to the specific filter documentation.
> 
> 
> 
> ## <input_interfaces>.filter_chain
> 
> Instead of a single configuration, a distinct configuration can be provided for each input interface. The key is the name of the input interface, and the value is a map of parameters that defines a filter chain, containing filterN as key. The fields for each filter are: type: The filter plugin to be loaded name: Actual name semantically describing the filter, e.g., low_pass_filter params: And underlying map of parameters needed for a specific filter, refer to the specific filter 