### PR TITLE
Remove deprecated tl_expected dependency

### DIFF
--- a/generate_parameter_library/cmake/generate_parameter_library.cmake
+++ b/generate_parameter_library/cmake/generate_parameter_library.cmake
@@ -81,19 +81,11 @@ macro(generate_parameter_library LIB_NAME YAML_FILE)
     rsl::rsl
     tcb_span::tcb_span
     tl::expected
-    # for backward compatibility
-    # remove once this redirection is removed
-    # https://github.com/PickNikRobotics/cpp_polyfills/pull/12
-    tl_expected::tl_expected
   )
   install(DIRECTORY ${LIB_INCLUDE_DIR} DESTINATION include)
   ament_export_dependencies(
     fmt rclcpp rclcpp_lifecycle rsl tcb_span
     tl-expected
-    # for backward compatibility
-    # remove once this redirection is removed
-    # https://github.com/PickNikRobotics/cpp_polyfills/pull/12
-    tl_expected
   )
 endmacro()
 

--- a/generate_parameter_library/generate_parameter_library-extras.cmake
+++ b/generate_parameter_library/generate_parameter_library-extras.cmake
@@ -32,10 +32,5 @@ find_package(rsl REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(tcb_span REQUIRED)
 find_package(tl-expected REQUIRED)
-# for backward compatibility
-# remove once this redirection is removed
-# https://github.com/PickNikRobotics/cpp_polyfills/pull/12
-set(tl_expected_DEPRECATED_QUIET TRUE)
-find_package(tl_expected REQUIRED)
 
 include("${generate_parameter_library_DIR}/generate_parameter_library.cmake")

--- a/generate_parameter_library/package.xml
+++ b/generate_parameter_library/package.xml
@@ -25,11 +25,6 @@
   <depend>tcb_span</depend>
   <depend>libexpected-dev</depend>
 
-  <!-- for backward compatibility -->
-  <!-- remove once this redirection is removed -->
-  <!-- https://github.com/PickNikRobotics/cpp_polyfills/pull/12 -->
-  <depend>tl_expected</depend>
-
   <export>
     <build_type>ament_cmake</build_type>
     <rosdoc2>rosdoc2.yaml</rosdoc2>


### PR DESCRIPTION
Removal after https://github.com/PickNikRobotics/generate_parameter_library/pull/322

@otamachan Is it ready for removal? cpp_polyfills 2.0.2 including deprecation warning got synced to rolling-main on noble, so we can remove it with the next release.

https://github.com/PickNikRobotics/cpp_polyfills/pull/25
