### PR TITLE
add gitignore for generated files in example_python

### DIFF
--- a/example_python/generate_parameter_module_example/.gitignore
+++ b/example_python/generate_parameter_module_example/.gitignore
@@ -1,0 +1,2 @@
+__init__.py
+admittance_parameters.py


### PR DESCRIPTION
When having the repo checked out locally, building the workspace leads to untracked files in this git repo. I think it's safe to just gitignore them since they are autogenerated anyways.