### PR TITLE
[CI] Add compatibility CI build

### DIFF
--- a/.github/workflows/rolling-combatibility-binary-build.yaml
+++ b/.github/workflows/rolling-combatibility-binary-build.yaml
@@ -1,0 +1,29 @@
+name: Rolling Compatibility Binary Build
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+# description: 'Build & test the rolling version on stable distros.'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
+jobs:
+  ci:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [kilted, jazzy, humble]
+    with:
+      ros_distro: ${{ matrix.ROS_DISTRO }}
+      ros_repo: testing
+      ref_for_scheduled_build: main


### PR DESCRIPTION
This tests the rolling version on stable distros (kilted, jazzy, humble as of now). This ensures that users can use the latest (breaking) changes by building this package from source in their workspace.