### PR TITLE
fix that if no parameter is updated, the user callback is not called

### DIFF
--- a/example/test/example_test_gtest.cpp
+++ b/example/test/example_test_gtest.cpp
@@ -85,7 +85,8 @@ TEST_F(ExampleTest, try_get_params) {
 TEST_F(ExampleTest, update_unrelated_param) {
   ASSERT_TRUE(param_listener_->try_get_params(params_));
 
-  // if some unrelated parameter is updated, the params_ should not be updated/considered as old
+  // if some unrelated parameter is updated, the params_ should not be
+  // updated/considered as old
   example_test_node_->declare_parameter("some_other_parameter", 42);
   ASSERT_FALSE(param_listener_->is_old(params_));
   const rclcpp ::Parameter new_param("some_other_parameter", 43);

--- a/example/test/example_test_gtest.cpp
+++ b/example/test/example_test_gtest.cpp
@@ -82,6 +82,17 @@ TEST_F(ExampleTest, try_get_params) {
   ASSERT_EQ(params_.interpolation_mode, "linear");
 }
 
+TEST_F(ExampleTest, update_unrelated_param) {
+  ASSERT_TRUE(param_listener_->try_get_params(params_));
+
+  // if some unrelated parameter is updated, the params_ should not be updated/considered as old
+  example_test_node_->declare_parameter("some_other_parameter", 42);
+  ASSERT_FALSE(param_listener_->is_old(params_));
+  const rclcpp ::Parameter new_param("some_other_parameter", 43);
+  example_test_node_->set_parameter(new_param);
+  ASSERT_FALSE(param_listener_->is_old(params_));
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);

--- a/example/test/launch.test.py
+++ b/example/test/launch.test.py
@@ -78,7 +78,7 @@ class TestFixture(unittest.TestCase):
         while time.time() - start < 5.0 and not found:
             found = node_name in self.node.get_node_names()
             time.sleep(0.1)
-        assert found, f"{node_name} not found!"
+        assert found, f'{node_name} not found!'
 
 
 @launch_testing.post_shutdown_test()

--- a/example_external/test/launch.test.py
+++ b/example_external/test/launch.test.py
@@ -80,7 +80,7 @@ class TestFixture(unittest.TestCase):
         while time.time() - start < 5.0 and not found:
             found = node_name in self.node.get_node_names()
             time.sleep(0.1)
-        assert found, f"{node_name} not found!"
+        assert found, f'{node_name} not found!'
 
 
 @launch_testing.post_shutdown_test()

--- a/example_python/test/test_params_consistency.py
+++ b/example_python/test/test_params_consistency.py
@@ -544,6 +544,12 @@ class TestParamsConsistency(unittest.TestCase):
             params.nested_map_struct.get_entry('B').nested_struct.nested_struct_field,
         )
 
+    def test_update_unrelated_param_does_not_mark_params_as_old(self):
+        params_before = self.listener.get_params()
+        self.node.declare_parameter('some_other_parameter', 42)
+        self.node.set_parameters([Parameter('some_other_parameter', value=43)])
+        self.assertFalse(self.listener.is_old(params_before))
+
 
 def main():
     unittest.main()

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/parameter_library_header
@@ -183,6 +183,7 @@ struct StackParams {
 
     rcl_interfaces::msg::SetParametersResult update(const std::vector<rclcpp::Parameter> &parameters) {
       auto updated_params = get_params();
+      bool any_param_updated = false;
 
       for (const auto &param: parameters) {
 {%- filter indent(width=8) %}
@@ -197,10 +198,12 @@ struct StackParams {
 {%- endfilter %}
       }
 {%- endif %}
-      updated_params.__stamp = clock_.now();
-      update_internal_params(updated_params);
-      if (user_callback_) {
-         user_callback_(updated_params);
+      if (any_param_updated) {
+        updated_params.__stamp = clock_.now();
+        update_internal_params(updated_params);
+        if (user_callback_) {
+          user_callback_(updated_params);
+        }
       }
       return rsl::to_parameter_result_msg({});
     }

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/update_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/update_parameter
@@ -4,6 +4,7 @@ if (param.get_name() == (prefix_ + "{{parameter_name}}")) {
 {{parameter_validations-}}
 {% endif -%}
 updated_params.{{parameter_name}} = param.{{parameter_as_function}};
+any_param_updated = true;
 RCLCPP_DEBUG_STREAM(logger_, param.get_name() << ": " << param.get_type_name() << " = " << param.value_to_string());
 {% endfilter -%}
 }

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/update_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/cpp/update_runtime_parameter
@@ -19,6 +19,7 @@ updated_params.{{struct_name}}{% for map in parameter_map%}.{{map}}[value_{{loop
 {% else %}
 updated_params{% for map in parameter_map%}.{{map}}[value_{{loop.index}}]{% endfor %}.{{parameter_field}} = param.{{parameter_as_function}};
 {% endif -%}
+any_param_updated = true;
 RCLCPP_DEBUG_STREAM(logger_, param.get_name() << ": " << param.get_type_name() << " = " << param.value_to_string());
 {% endfilter -%}
 }

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/parameter_library_header
@@ -105,6 +105,7 @@ self.stamp_ = Time()
 
         def update(self, parameters):
             updated_params = self.get_params()
+            any_param_updated = False
 
             for param in parameters:
 {%- filter indent(width=16) %}
@@ -120,10 +121,11 @@ for param in parameters:
 {%- endfilter %}
 {%- endif %}
 
-            updated_params.stamp_ = self.clock_.now()
-            self.update_internal_params(updated_params)
-            if self.user_callback:
-                self.user_callback(self.get_params())
+            if any_param_updated:
+                updated_params.stamp_ = self.clock_.now()
+                self.update_internal_params(updated_params)
+                if self.user_callback:
+                    self.user_callback(self.get_params())
             return SetParametersResult(successful=True)
 
         def update_internal_params(self, updated_params):

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/update_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/update_parameter
@@ -4,5 +4,6 @@ if param.name == self.prefix_ + "{{parameter_name}}":
 {{parameter_validations-}}
 {% endif -%}
 updated_params.{{parameter_name}} = param.{{parameter_as_function}}
+any_param_updated = True
 self.logger_.debug(param.name + ": " + param.type_.name + " = " + str(param.value))
 {% endfilter -%}

--- a/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/update_runtime_parameter
+++ b/generate_parameter_library_py/generate_parameter_library_py/jinja_templates/python/update_runtime_parameter
@@ -19,6 +19,7 @@ updated_params.{{struct_name}}{% for map in parameter_map%}.get_entry(value_{{lo
 {% else %}
 updated_params{% for map in parameter_map%}.get_entry(value_{{loop.index}}){% endfor %}.{{parameter_field}} = param.{{parameter_as_function}}
 {% endif -%}
+any_param_updated = True
 self.logger_.debug(param.name + ": " + param.type_.name + " = " + str(param.value))
 {% endfilter -%}
 {% endfilter -%}


### PR DESCRIPTION
This can be the case if one node has multiple param listeners in multiple namespaces and then the `add_on_set_parameters_callback` is called for all the parameter changes and not just for the relevant ones.